### PR TITLE
Update googleapis to the latest version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,7 +70,7 @@ bind(
 
 new_git_repository(
     name = "googleapis_git",
-    commit = "2608c0a7a988c62ac1c5f38c7f1f0516430ad1de",
+    commit = "27156597fdf4fb77004434d4409154a230dc9a32", # common-protos-1_3_1
     remote = "https://github.com/googleapis/googleapis.git",
     build_file = "third_party/BUILD.googleapis",
 )


### PR DESCRIPTION
Updating googleapis to the latest version as the current googleapis SHA
does not exist in googleapis repo in GitHub anymore

Change-Id: I6b7291ad7b0de28ebf2902276853e8e767cd13ac