### PR TITLE
Added unit tests for ServiceControlClientImpl::Quota methods

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -144,8 +144,8 @@ cc_test(
     name = "service_control_client_impl_test",
     size = "small",
     srcs = [
+        "src/mock_transport.h",
         "src/service_control_client_impl_test.cc",
-        "src/service_control_client_impl_test.h",
     ],
     linkopts = ["-lm"],
     deps = [
@@ -158,8 +158,8 @@ cc_test(
     name = "service_control_client_impl_quota_test",
     size = "small",
     srcs = [
+        "src/mock_transport.h",
         "src/service_control_client_impl_quota_test.cc",
-        "src/service_control_client_impl_test.h",
     ],
     linkopts = ["-lm"],
     deps = [

--- a/BUILD
+++ b/BUILD
@@ -143,7 +143,24 @@ cc_test(
 cc_test(
     name = "service_control_client_impl_test",
     size = "small",
-    srcs = ["src/service_control_client_impl_test.cc"],
+    srcs = [
+        "src/service_control_client_impl_test.cc",
+        "src/service_control_client_impl_test.h",
+    ],
+    linkopts = ["-lm"],
+    deps = [
+        ":service_control_client_lib",
+        "//external:googletest_main",
+    ],
+)
+
+cc_test(
+    name = "service_control_client_impl_quota_test",
+    size = "small",
+    srcs = [
+        "src/service_control_client_impl_quota_test.cc",
+        "src/service_control_client_impl_test.h",
+    ],
     linkopts = ["-lm"],
     deps = [
         ":service_control_client_lib",

--- a/include/service_control_client.h
+++ b/include/service_control_client.h
@@ -305,6 +305,20 @@ class ServiceControlClient {
       ::google::api::servicecontrol::v1::CheckResponse* check_response,
       DoneCallback on_check_done, TransportCheckFunc check_transport) = 0;
 
+  // An async quota call.
+  virtual void Quota(
+      const ::google::api::servicecontrol::v1::AllocateQuotaRequest&
+          quota_request,
+      ::google::api::servicecontrol::v1::AllocateQuotaResponse* quota_response,
+      DoneCallback on_quota_done) = 0;
+
+  // A sync quota call.
+  virtual ::google::protobuf::util::Status Quota(
+      const ::google::api::servicecontrol::v1::AllocateQuotaRequest&
+          quota_request,
+      ::google::api::servicecontrol::v1::AllocateQuotaResponse*
+          quota_response) = 0;
+
   // A allocateQuota call with provided per_request transport function.
   // Only some special platforms may need to use this function.
   // It allows caller to pass in a per_request transport function.

--- a/src/mock_transport.h
+++ b/src/mock_transport.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#ifndef GOOGLE_SERVICE_CONTROL_CLIENT_SERVICE_CONTROL_CLIENT_IMPL_TEST_H_
-#define GOOGLE_SERVICE_CONTROL_CLIENT_SERVICE_CONTROL_CLIENT_IMPL_TEST_H_
+#ifndef GOOGLE_SERVICE_CONTROL_CLIENT_MOCK_TRANSPORT_H_
+#define GOOGLE_SERVICE_CONTROL_CLIENT_MOCK_TRANSPORT_H_
 
 #include "include/service_control_client.h"
 
@@ -131,8 +131,6 @@ class MockQuotaTransport {
   TransportQuotaFunc GetFunc() {
     return [this](const AllocateQuotaRequest& request, AllocateQuotaResponse* response,
                   TransportDoneFunc on_done) {
-      std::cout << __FILE__ << ":" << __LINE__ << " " << std::endl;
-
       this->Quota(request, response, on_done);
     };
   }
@@ -309,4 +307,4 @@ class MockPeriodicTimer {
 }  // namespace service_control_client
 }  // namespace google
 
-#endif  // GOOGLE_SERVICE_CONTROL_CLIENT_SERVICE_CONTROL_CLIENT_IMPL_TEST_H_
+#endif  // GOOGLE_SERVICE_CONTROL_CLIENT_MOCK_TRANSPORT_H_

--- a/src/mock_transport.h
+++ b/src/mock_transport.h
@@ -121,16 +121,15 @@ class MockCheckTransport {
   std::vector<std::unique_ptr<std::thread>> callback_threads_;
 };
 
-
 // A mocking class to mock QuotaTransport interface.
 class MockQuotaTransport {
  public:
-  MOCK_METHOD3(Quota,
-               void(const AllocateQuotaRequest&, AllocateQuotaResponse*, TransportDoneFunc));
+  MOCK_METHOD3(Quota, void(const AllocateQuotaRequest&, AllocateQuotaResponse*,
+                           TransportDoneFunc));
 
   TransportQuotaFunc GetFunc() {
-    return [this](const AllocateQuotaRequest& request, AllocateQuotaResponse* response,
-                  TransportDoneFunc on_done) {
+    return [this](const AllocateQuotaRequest& request,
+                  AllocateQuotaResponse* response, TransportDoneFunc on_done) {
       this->Quota(request, response, on_done);
     };
   }
@@ -148,8 +147,8 @@ class MockQuotaTransport {
 
   // The done callback is stored in on_done_. It MUST be called later.
   void AllocateQuotaWithStoredCallback(const AllocateQuotaRequest& request,
-                               AllocateQuotaResponse* response,
-                               TransportDoneFunc on_done) {
+                                       AllocateQuotaResponse* response,
+                                       TransportDoneFunc on_done) {
     quota_request_ = request;
     if (quota_response_) {
       *response = *quota_response_;
@@ -159,8 +158,8 @@ class MockQuotaTransport {
 
   // The done callback is called right away (in place).
   void AllocateQuotaWithInplaceCallback(const AllocateQuotaRequest& request,
-                                AllocateQuotaResponse* response,
-                                TransportDoneFunc on_done) {
+                                        AllocateQuotaResponse* response,
+                                        TransportDoneFunc on_done) {
     quota_request_ = request;
     if (quota_response_) {
       *response = *quota_response_;
@@ -169,8 +168,9 @@ class MockQuotaTransport {
   }
 
   // The done callback is called from a separate thread with quota_status_
-  void AllocateQuotaUsingThread(const AllocateQuotaRequest& request, AllocateQuotaResponse* response,
-                        TransportDoneFunc on_done) {
+  void AllocateQuotaUsingThread(const AllocateQuotaRequest& request,
+                                AllocateQuotaResponse* response,
+                                TransportDoneFunc on_done) {
     quota_request_ = request;
     Status done_status = done_status_;
     AllocateQuotaResponse* quota_response = quota_response_;
@@ -196,8 +196,6 @@ class MockQuotaTransport {
   // A vector to store thread objects used to call on_done callback.
   std::vector<std::unique_ptr<std::thread>> callback_threads_;
 };
-
-
 
 // A mocking class to mock ReportTransport interface.
 class MockReportTransport {
@@ -300,7 +298,6 @@ class MockPeriodicTimer {
   int interval_ms_;
   std::function<void()> callback_;
 };
-
 
 }  // namespace
 

--- a/src/service_control_client_impl_quota_test.cc
+++ b/src/service_control_client_impl_quota_test.cc
@@ -1,0 +1,372 @@
+/* Copyright 2017 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "src/service_control_client_impl_test.h"
+
+namespace google {
+namespace service_control_client {
+
+namespace {
+
+const char kServiceName[] = "library.googleapis.com";
+const char kServiceConfigId[] = "2016-09-19r0";
+
+const char kRequest1[] = R"(
+service_name: "library.googleapis.com"
+allocate_operation {
+  operation_id: "operation-1"
+  method_name: "methodname"
+  consumer_id: "consumerid"
+  quota_metrics {
+    metric_name: "metric_first"
+    metric_values {
+      int64_value: 1
+    }
+  }
+  quota_metrics {
+    metric_name: "metric_second"
+    metric_values {
+      int64_value: 1
+    }
+  }
+  quota_mode: NORMAL
+}
+service_config_id: "2016-09-19r0"
+)";
+
+const char kSuccessResponse1[] = R"(
+operation_id: "operation-1"
+quota_metrics {
+  metric_name: "serviceruntime.googleapis.com/api/consumer/quota_used_count"
+  metric_values {
+    labels {
+      key: "/quota_name"
+      value: "metric_first"
+    }
+    int64_value: 1
+  }
+  metric_values {
+    labels {
+      key: "/quota_name"
+      value: "metric_first"
+    }
+    int64_value: 1
+  }
+}
+service_config_id: "2016-09-19r0"
+)";
+
+const char kErrorResponse1[] = R"(
+operation_id: "a197c6f2-aecc-4a31-9744-b1d5aea4e4b4"
+allocate_errors {
+  code: RESOURCE_EXHAUSTED
+  subject: "user:integration_test_user"
+}
+)";
+
+}  // namespace
+
+class ServiceControlClientImplQuotaTest : public ::testing::Test {
+ public:
+  void SetUp() {
+    ASSERT_TRUE(TextFormat::ParseFromString(kRequest1, &quota_request1_));
+    ASSERT_TRUE(
+        TextFormat::ParseFromString(kSuccessResponse1, &pass_quota_response1_));
+    ASSERT_TRUE(
+        TextFormat::ParseFromString(kErrorResponse1, &error_quota_response1_));
+  }
+
+  AllocateQuotaRequest quota_request1_;
+  AllocateQuotaResponse pass_quota_response1_;
+  AllocateQuotaResponse error_quota_response1_;
+
+  MockCheckTransport mock_check_transport_;
+  MockQuotaTransport mock_quota_transport_;
+  MockReportTransport mock_report_transport_;
+};
+
+TEST_F(ServiceControlClientImplQuotaTest,
+       TestNonCachedQuotaWithStoredCallback) {
+  ServiceControlClientOptions options(CheckAggregationOptions(0, 500, 1000),
+                                      QuotaAggregationOptions(0, 500),
+                                      ReportAggregationOptions(0, 500));
+
+  options.check_transport = mock_check_transport_.GetFunc();
+  options.report_transport = mock_report_transport_.GetFunc();
+
+  int callbackCalledCount = 0;
+  options.quota_transport = [this, &callbackCalledCount](
+      const AllocateQuotaRequest& request, AllocateQuotaResponse* response,
+      TransportDoneFunc on_done) {
+    response = &pass_quota_response1_;
+
+    callbackCalledCount++;
+    on_done(Status::OK);
+  };
+
+  std::unique_ptr<ServiceControlClient> client_ =
+      CreateServiceControlClient(kServiceName, kServiceConfigId, options);
+
+  Status done_status = Status::UNKNOWN;
+  AllocateQuotaResponse quota_response;
+
+  client_->Quota(quota_request1_, &quota_response,
+                 [&done_status](Status status) { done_status = status; });
+  ASSERT_TRUE(TextFormat::ParseFromString(kSuccessResponse1, &quota_response));
+
+  for (int i = 0; i < 10; i++) {
+    client_->Quota(quota_request1_, &quota_response,
+                   [&done_status](Status status) { done_status = status; });
+    ASSERT_TRUE(
+        TextFormat::ParseFromString(kSuccessResponse1, &quota_response));
+  }
+  EXPECT_EQ(done_status, Status::OK);
+
+  EXPECT_EQ(callbackCalledCount, 11);
+
+  Statistics stat;
+  Status stat_status = client_->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 11);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 11);
+
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaWithStoredCallback) {
+  ServiceControlClientOptions options(CheckAggregationOptions(0, 500, 1000),
+                                      QuotaAggregationOptions(10, 500),
+                                      ReportAggregationOptions(0, 500));
+
+  options.check_transport = mock_check_transport_.GetFunc();
+  options.report_transport = mock_report_transport_.GetFunc();
+
+  int callbackCalledCount = 0;
+  options.quota_transport = [&callbackCalledCount](
+      const AllocateQuotaRequest& request, AllocateQuotaResponse* response,
+      TransportDoneFunc on_done) {
+    callbackCalledCount++;
+    on_done(Status::OK);
+  };
+
+  std::unique_ptr<ServiceControlClient> client_ =
+      CreateServiceControlClient(kServiceName, kServiceConfigId, options);
+
+  Status done_status = Status::UNKNOWN;
+  AllocateQuotaResponse quota_response;
+
+  client_->Quota(quota_request1_, &quota_response,
+                 [&done_status](Status status) { done_status = status; });
+
+  for (int i = 0; i < 10; i++) {
+    client_->Quota(quota_request1_, &quota_response,
+                   [&done_status](Status status) { done_status = status; });
+  }
+
+  EXPECT_EQ(done_status, Status::OK);
+
+  EXPECT_EQ(callbackCalledCount, 1);
+
+  Statistics stat;
+  Status stat_status = client_->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 11);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 1);
+
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaWithCallback) {
+  ServiceControlClientOptions options(CheckAggregationOptions(0, 500, 1000),
+                                      QuotaAggregationOptions(0, 500),
+                                      ReportAggregationOptions(0, 500));
+
+  options.check_transport = mock_check_transport_.GetFunc();
+  options.quota_transport = mock_quota_transport_.GetFunc();
+  options.report_transport = mock_report_transport_.GetFunc();
+
+  int callbackCalledCount = 0;
+
+  std::unique_ptr<ServiceControlClient> client_ =
+      CreateServiceControlClient(kServiceName, kServiceConfigId, options);
+
+  Status done_status = Status::UNKNOWN;
+  AllocateQuotaResponse quota_response;
+
+  client_->Quota(quota_request1_, &quota_response,
+                 [&done_status](Status status) { done_status = status; },
+                 [&callbackCalledCount](const AllocateQuotaRequest& request,
+                                        AllocateQuotaResponse* response,
+                                        TransportDoneFunc on_done) {
+                   callbackCalledCount++;
+                   on_done(Status::OK);
+                 });
+
+  for (int i = 0; i < 10; i++) {
+    client_->Quota(quota_request1_, &quota_response,
+                   [&done_status](Status status) { done_status = status; },
+                   [&callbackCalledCount](const AllocateQuotaRequest& request,
+                                          AllocateQuotaResponse* response,
+                                          TransportDoneFunc on_done) {
+                     callbackCalledCount++;
+                     on_done(Status::OK);
+                   });
+  }
+
+  EXPECT_EQ(done_status, Status::OK);
+
+  EXPECT_EQ(callbackCalledCount, 11);
+
+  Statistics stat;
+  Status stat_status = client_->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 11);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 11);
+
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaWithCallback) {
+  ServiceControlClientOptions options(CheckAggregationOptions(0, 500, 1000),
+                                      QuotaAggregationOptions(10, 500),
+                                      ReportAggregationOptions(0, 500));
+
+  options.check_transport = mock_check_transport_.GetFunc();
+  options.quota_transport = mock_quota_transport_.GetFunc();
+  options.report_transport = mock_report_transport_.GetFunc();
+
+  int callbackCalledCount = 0;
+
+  std::unique_ptr<ServiceControlClient> client_ =
+      CreateServiceControlClient(kServiceName, kServiceConfigId, options);
+
+  Status done_status = Status::UNKNOWN;
+  AllocateQuotaResponse quota_response;
+
+  client_->Quota(quota_request1_, &quota_response,
+                 [&done_status](Status status) { done_status = status; },
+                 [&callbackCalledCount](const AllocateQuotaRequest& request,
+                                        AllocateQuotaResponse* response,
+                                        TransportDoneFunc on_done) {
+                   callbackCalledCount++;
+                   on_done(Status::OK);
+                 });
+
+  for (int i = 0; i < 10; i++) {
+    client_->Quota(quota_request1_, &quota_response,
+                   [&done_status](Status status) { done_status = status; },
+                   [&callbackCalledCount](const AllocateQuotaRequest& request,
+                                          AllocateQuotaResponse* response,
+                                          TransportDoneFunc on_done) {
+                     callbackCalledCount++;
+                     on_done(Status::OK);
+                   });
+  }
+
+  EXPECT_EQ(done_status, Status::OK);
+
+  EXPECT_EQ(callbackCalledCount, 1);
+
+  Statistics stat;
+  Status stat_status = client_->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 11);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 1);
+
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaInSync) {
+  EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
+      .WillRepeatedly(Invoke(&mock_quota_transport_,
+                             &MockQuotaTransport::AllocateQuotaUsingThread));
+
+  ServiceControlClientOptions options(CheckAggregationOptions(0, 500, 1000),
+                                      QuotaAggregationOptions(0, 500),
+                                      ReportAggregationOptions(0, 500));
+
+  options.check_transport = mock_check_transport_.GetFunc();
+  options.quota_transport = mock_quota_transport_.GetFunc();
+  options.report_transport = mock_report_transport_.GetFunc();
+
+  std::unique_ptr<ServiceControlClient> client_ =
+      CreateServiceControlClient(kServiceName, kServiceConfigId, options);
+
+  AllocateQuotaResponse quota_response;
+  Status done_status = client_->Quota(quota_request1_, &quota_response);
+  EXPECT_EQ(done_status, Status::OK);
+
+  for (int i = 0; i < 10; i++) {
+    done_status = client_->Quota(quota_request1_, &quota_response);
+    EXPECT_EQ(done_status, Status::OK);
+  }
+
+  Statistics stat;
+  Status stat_status = client_->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 11);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 11);
+
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaInSync) {
+  EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
+      .WillRepeatedly(Invoke(&mock_quota_transport_,
+                             &MockQuotaTransport::AllocateQuotaUsingThread));
+
+  ServiceControlClientOptions options(CheckAggregationOptions(0, 500, 1000),
+                                      QuotaAggregationOptions(10, 500),
+                                      ReportAggregationOptions(0, 500));
+
+  options.check_transport = mock_check_transport_.GetFunc();
+  options.quota_transport = mock_quota_transport_.GetFunc();
+  options.report_transport = mock_report_transport_.GetFunc();
+
+  std::unique_ptr<ServiceControlClient> client_ =
+      CreateServiceControlClient(kServiceName, kServiceConfigId, options);
+
+  AllocateQuotaResponse quota_response;
+  Status done_status = client_->Quota(quota_request1_, &quota_response);
+  EXPECT_EQ(done_status, Status::OK);
+
+  for (int i = 0; i < 10; i++) {
+    done_status = client_->Quota(quota_request1_, &quota_response);
+    EXPECT_EQ(done_status, Status::OK);
+  }
+
+  Statistics stat;
+  Status stat_status = client_->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 11);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 1);
+
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+}  // namespace service_control_client
+}  // namespace google

--- a/src/service_control_client_impl_quota_test.cc
+++ b/src/service_control_client_impl_quota_test.cc
@@ -544,7 +544,7 @@ TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaThread) {
                    moved_promise.set_value(status);
                  });
 
-  // Since it is not cached, transport should be called.
+  // since it is a cache miss, transport should be called.
   EXPECT_TRUE(MessageDifferencer::Equals(mock_quota_transport_.quota_request_,
                                          quota_request1_));
 

--- a/src/service_control_client_impl_quota_test.cc
+++ b/src/service_control_client_impl_quota_test.cc
@@ -182,7 +182,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(stat.send_quotas_in_flight, 0);
 }
 
-// Cache: false, Callback: stored
+// Cached: false, Callback: stored
 TEST_F(ServiceControlClientImplQuotaTest,
        TestNonCachedQuotaWithStoredCallback) {
   EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
@@ -213,7 +213,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(stat.send_quotas_in_flight, 1);
 }
 
-// Cache: false, Callback: stored
+// Cached: false, Callback: stored
 TEST_F(ServiceControlClientImplQuotaTest,
        TestNonCachedQuotaWithStoredCallbackMultipleReqeusts) {
   // Initialize client instance with cache disabled
@@ -262,7 +262,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(stat.send_quotas_in_flight, 10);
 }
 
-// Cache: true, Callback: stored
+// Cached: true, Callback: stored
 TEST_F(ServiceControlClientImplQuotaTest,
        TestCachedQuotaWithStoredCallbackMultipleRequests) {
   EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
@@ -299,7 +299,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(stat.send_quotas_in_flight, 1);
 }
 
-// Cache: false, Callback: in place
+// Cached: false, Callback: in place
 TEST_F(ServiceControlClientImplQuotaTest,
        TestNonCachedQuotaWithInPlaceCallbackMultipleReqeusts) {
   // Initialize client instance with cache disabled
@@ -341,7 +341,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(stat.send_quotas_in_flight, 10);
 }
 
-// Cache: false, Callback: in place
+// Cached: false, Callback: in place
 TEST_F(ServiceControlClientImplQuotaTest,
        TestNonCachedQuotaWithInPlaceCallback) {
   EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
@@ -368,7 +368,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(stat.send_quotas_in_flight, 1);
 }
 
-// Cache: false, Callback: in place
+// Cached: false, Callback: in place
 TEST_F(ServiceControlClientImplQuotaTest,
        TestCachedQuotaWithInPlaceCallbackMultipleRequests) {
   EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
@@ -402,7 +402,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(stat.send_quotas_in_flight, 1);
 }
 
-// Cache: false, Callback: local in place
+// Cached: false, Callback: local in place
 TEST_F(ServiceControlClientImplQuotaTest,
        TestNonCachedQuotaWithLocalInPlaceCallback) {
   Status done_status = Status::UNKNOWN;
@@ -436,7 +436,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(stat.send_quotas_in_flight, 1);
 }
 
-// Cache: false, Callback: in place
+// Cached: false, Callback: in place
 TEST_F(ServiceControlClientImplQuotaTest,
        TestNonCachedQuotaWithInPlaceCallbackInSync) {
   EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
@@ -461,7 +461,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(stat.send_quotas_in_flight, 1);
 }
 
-// Cache: true, Callback: in place
+// Cached: true, Callback: in place
 TEST_F(ServiceControlClientImplQuotaTest,
        TestCachedQuotaWithInPlaceCallbackInSyncMultipleRequests) {
   EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
@@ -487,7 +487,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(stat.send_quotas_in_flight, 1);
 }
 
-// Cache: true, Callback: thread
+// Cached: true, Callback: thread
 TEST_F(ServiceControlClientImplQuotaTest,
        TestCachedQuotaInSyncThreadMultipleRequests) {
   EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
@@ -522,7 +522,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(stat.send_quotas_in_flight, 1);
 }
 
-// Cache: false, Callback: thread
+// Cached: false, Callback: thread
 TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaThread) {
   EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
       .WillRepeatedly(Invoke(&mock_quota_transport_,
@@ -560,7 +560,7 @@ TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaThread) {
   EXPECT_EQ(stat.send_quotas_in_flight, 1);
 }
 
-// Cache: true, Callback: thread
+// Cached: true, Callback: thread
 TEST_F(ServiceControlClientImplQuotaTest,
        TestCachedQuotaThreadMultipleRequests) {
   EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))

--- a/src/service_control_client_impl_quota_test.cc
+++ b/src/service_control_client_impl_quota_test.cc
@@ -98,8 +98,8 @@ class ServiceControlClientImplQuotaTest : public ::testing::Test {
     cached_options.quota_transport = mock_quota_transport_.GetFunc();
     cached_options.report_transport = mock_report_transport_.GetFunc();
 
-    client_cached_ = CreateServiceControlClient(kServiceName, kServiceConfigId,
-                                                cached_options);
+    client_ = CreateServiceControlClient(kServiceName, kServiceConfigId,
+                                         cached_options);
 
     // Initialize the client instance with cache disabled
     ServiceControlClientOptions noncached_options(
@@ -110,7 +110,7 @@ class ServiceControlClientImplQuotaTest : public ::testing::Test {
     noncached_options.quota_transport = mock_quota_transport_.GetFunc();
     noncached_options.report_transport = mock_report_transport_.GetFunc();
 
-    client_non_cached_ = CreateServiceControlClient(
+    noncached_client_ = CreateServiceControlClient(
         kServiceName, kServiceConfigId, noncached_options);
   }
 
@@ -122,8 +122,8 @@ class ServiceControlClientImplQuotaTest : public ::testing::Test {
   MockQuotaTransport mock_quota_transport_;
   MockReportTransport mock_report_transport_;
 
-  std::unique_ptr<ServiceControlClient> client_cached_;
-  std::unique_ptr<ServiceControlClient> client_non_cached_;
+  std::unique_ptr<ServiceControlClient> client_;
+  std::unique_ptr<ServiceControlClient> noncached_client_;
 };
 
 // Error on different service name
@@ -209,7 +209,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
 
   // call Quota 10 times
   for (int i = 0; i < 10; i++) {
-    client_non_cached_->Quota(
+    noncached_client_->Quota(
         quota_request1_, &quota_response,
         [&done_status](Status status) { done_status = status; });
     EXPECT_EQ(done_status, Status::UNKNOWN);
@@ -226,7 +226,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   }
 
   Statistics stat;
-  Status stat_status = client_non_cached_->GetStatistics(&stat);
+  Status stat_status = noncached_client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
   EXPECT_EQ(stat.total_called_quotas, 10);
@@ -244,16 +244,14 @@ TEST_F(ServiceControlClientImplQuotaTest,
   Status done_status = Status::UNKNOWN;
   AllocateQuotaResponse quota_response;
 
-  client_cached_->Quota(
-      quota_request1_, &quota_response,
-      [&done_status](Status status) { done_status = status; });
+  client_->Quota(quota_request1_, &quota_response,
+                 [&done_status](Status status) { done_status = status; });
   EXPECT_EQ(done_status, Status::UNKNOWN);
 
   // call Quota 10 times
   for (int i = 0; i < 10; i++) {
-    client_cached_->Quota(
-        quota_request1_, &quota_response,
-        [&done_status](Status status) { done_status = status; });
+    client_->Quota(quota_request1_, &quota_response,
+                   [&done_status](Status status) { done_status = status; });
     EXPECT_EQ(done_status, Status::OK);
   }
 
@@ -265,7 +263,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(done_status, Status::OK);
 
   Statistics stat;
-  Status stat_status = client_cached_->GetStatistics(&stat);
+  Status stat_status = client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
   EXPECT_EQ(stat.total_called_quotas, 11);
@@ -286,7 +284,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
 
   // call Quota 10 times
   for (int i = 0; i < 10; i++) {
-    client_non_cached_->Quota(
+    noncached_client_->Quota(
         quota_request1_, &quota_response,
         [&done_status](Status status) { done_status = status; });
     EXPECT_EQ(done_status, Status::OK);
@@ -296,7 +294,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
 
   Statistics stat;
-  Status stat_status = client_non_cached_->GetStatistics(&stat);
+  Status stat_status = noncached_client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
   EXPECT_EQ(stat.total_called_quotas, 10);
@@ -314,7 +312,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   Status done_status = Status::UNKNOWN;
   AllocateQuotaResponse quota_response;
 
-  client_non_cached_->Quota(
+  noncached_client_->Quota(
       quota_request1_, &quota_response,
       [&done_status](Status status) { done_status = status; });
 
@@ -324,7 +322,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
 
   Statistics stat;
-  Status stat_status = client_non_cached_->GetStatistics(&stat);
+  Status stat_status = noncached_client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
   EXPECT_EQ(stat.total_called_quotas, 1);
@@ -343,7 +341,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   Status done_status = Status::UNKNOWN;
   AllocateQuotaResponse quota_response;
 
-  client_non_cached_->Quota(
+  noncached_client_->Quota(
       quota_request1_, &quota_response,
       [&done_status](Status status) { done_status = status; });
 
@@ -351,7 +349,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
 
   // call Quota 10 times
   for (int i = 0; i < 10; i++) {
-    client_non_cached_->Quota(
+    noncached_client_->Quota(
         quota_request1_, &quota_response,
         [&done_status](Status status) { done_status = status; });
     EXPECT_EQ(done_status, Status::OK);
@@ -361,7 +359,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
 
   Statistics stat;
-  Status stat_status = client_non_cached_->GetStatistics(&stat);
+  Status stat_status = noncached_client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
   EXPECT_EQ(stat.total_called_quotas, 11);
@@ -377,7 +375,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
 
   int callbackExecuteCount = 0;
 
-  client_non_cached_->Quota(
+  noncached_client_->Quota(
       quota_request1_, &quota_response,
       [&done_status](Status status) { done_status = status; },
       [this, &callbackExecuteCount](const AllocateQuotaRequest& request,
@@ -395,7 +393,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
 
   Statistics stat;
-  Status stat_status = client_non_cached_->GetStatistics(&stat);
+  Status stat_status = noncached_client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
   EXPECT_EQ(stat.total_called_quotas, 1);
@@ -413,7 +411,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   AllocateQuotaResponse quota_response;
 
   Status done_status =
-      client_non_cached_->Quota(quota_request1_, &quota_response);
+      noncached_client_->Quota(quota_request1_, &quota_response);
 
   EXPECT_EQ(done_status, Status::OK);
 
@@ -421,7 +419,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
 
   Statistics stat;
-  Status stat_status = client_non_cached_->GetStatistics(&stat);
+  Status stat_status = noncached_client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
   EXPECT_EQ(stat.total_called_quotas, 1);
@@ -439,8 +437,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   AllocateQuotaResponse quota_response;
 
   for (int i = 0; i < 10; i++) {
-    Status done_status =
-        client_cached_->Quota(quota_request1_, &quota_response);
+    Status done_status = client_->Quota(quota_request1_, &quota_response);
     EXPECT_EQ(done_status, Status::OK);
   }
 
@@ -448,7 +445,7 @@ TEST_F(ServiceControlClientImplQuotaTest,
   EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
 
   Statistics stat;
-  Status stat_status = client_cached_->GetStatistics(&stat);
+  Status stat_status = client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
   EXPECT_EQ(stat.total_called_quotas, 10);
@@ -470,20 +467,20 @@ TEST_F(ServiceControlClientImplQuotaTest,
   mock_quota_transport_.done_status_ = done_status;
   mock_quota_transport_.quota_response_ = &quota_response;
 
-  done_status = client_cached_->Quota(quota_request1_, &quota_response);
+  done_status = client_->Quota(quota_request1_, &quota_response);
   EXPECT_TRUE(MessageDifferencer::Equals(mock_quota_transport_.quota_request_,
                                          quota_request1_));
   EXPECT_EQ(done_status, Status::OK);
 
   for (int i = 0; i < 10; i++) {
-    done_status = client_cached_->Quota(quota_request1_, &quota_response);
+    done_status = client_->Quota(quota_request1_, &quota_response);
     EXPECT_TRUE(MessageDifferencer::Equals(mock_quota_transport_.quota_request_,
                                            quota_request1_));
     EXPECT_EQ(done_status, Status::OK);
   }
 
   Statistics stat;
-  Status stat_status = client_cached_->GetStatistics(&stat);
+  Status stat_status = client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
   EXPECT_EQ(stat.total_called_quotas, 11);
@@ -507,7 +504,7 @@ TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaThread) {
   StatusPromise status_promise;
   StatusFuture status_future = status_promise.get_future();
 
-  client_non_cached_->Quota(
+  noncached_client_->Quota(
       quota_request1_, &quota_response,
       [&status_promise, &done_status](Status status) {
         StatusPromise moved_promise(std::move(status_promise));
@@ -522,7 +519,7 @@ TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaThread) {
   EXPECT_EQ(status_future.get(), Status::OK);
 
   Statistics stat;
-  Status stat_status = client_non_cached_->GetStatistics(&stat);
+  Status stat_status = noncached_client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
   EXPECT_EQ(stat.total_called_quotas, 1);
@@ -546,27 +543,26 @@ TEST_F(ServiceControlClientImplQuotaTest,
 
   StatusPromise status_promise;
   StatusFuture status_future = status_promise.get_future();
-  client_cached_->Quota(
-      quota_request1_, &quota_response,
-      [&status_promise, &done_status](Status status) {
-        StatusPromise moved_promise(std::move(status_promise));
-        moved_promise.set_value(status);
-      });
+  client_->Quota(quota_request1_, &quota_response,
+                 [&status_promise, &done_status](Status status) {
+                   StatusPromise moved_promise(std::move(status_promise));
+                   moved_promise.set_value(status);
+                 });
   EXPECT_TRUE(MessageDifferencer::Equals(mock_quota_transport_.quota_request_,
                                          quota_request1_));
 
   for (int i = 0; i < 10; i++) {
-    client_cached_->Quota(quota_request1_, &quota_response,
-                          [&status_promise, &done_status](Status status) {
-                            EXPECT_EQ(status, Status::OK);
-                          });
+    client_->Quota(quota_request1_, &quota_response,
+                   [&status_promise, &done_status](Status status) {
+                     EXPECT_EQ(status, Status::OK);
+                   });
   }
 
   status_future.wait();
   EXPECT_EQ(status_future.get(), Status::OK);
 
   Statistics stat;
-  Status stat_status = client_cached_->GetStatistics(&stat);
+  Status stat_status = client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
   EXPECT_EQ(stat.total_called_quotas, 11);

--- a/src/service_control_client_impl_quota_test.cc
+++ b/src/service_control_client_impl_quota_test.cc
@@ -13,7 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#include "src/service_control_client_impl_test.h"
+#include "src/mock_transport.h"
 
 namespace google {
 namespace service_control_client {
@@ -69,7 +69,7 @@ service_config_id: "2016-09-19r0"
 )";
 
 const char kErrorResponse1[] = R"(
-operation_id: "a197c6f2-aecc-4a31-9744-b1d5aea4e4b4"
+operation_id: "operation-1"
 allocate_errors {
   code: RESOURCE_EXHAUSTED
   subject: "user:integration_test_user"
@@ -86,6 +86,19 @@ class ServiceControlClientImplQuotaTest : public ::testing::Test {
         TextFormat::ParseFromString(kSuccessResponse1, &pass_quota_response1_));
     ASSERT_TRUE(
         TextFormat::ParseFromString(kErrorResponse1, &error_quota_response1_));
+
+    ServiceControlClientOptions options(
+        CheckAggregationOptions(1 /*entries */, 500 /* refresh_interval_ms */,
+                                1000 /* expiration_ms */),
+        QuotaAggregationOptions(1 /*entries */, 500 /* refresh_interval_ms */),
+        ReportAggregationOptions(1 /* entries */, 500 /*flush_interval_ms*/));
+
+    options.check_transport = mock_check_transport_.GetFunc();
+    options.quota_transport = mock_quota_transport_.GetFunc();
+    options.report_transport = mock_report_transport_.GetFunc();
+
+    client_ =
+        CreateServiceControlClient(kServiceName, kServiceConfigId, options);
   }
 
   AllocateQuotaRequest quota_request1_;
@@ -95,91 +108,189 @@ class ServiceControlClientImplQuotaTest : public ::testing::Test {
   MockCheckTransport mock_check_transport_;
   MockQuotaTransport mock_quota_transport_;
   MockReportTransport mock_report_transport_;
+
+  std::unique_ptr<ServiceControlClient> client_;
 };
 
+// Error on different service name
+TEST_F(ServiceControlClientImplQuotaTest, TestQuotaWithInvalidServiceName) {
+  ServiceControlClientOptions options(CheckAggregationOptions(1, 500, 1000),
+                                      QuotaAggregationOptions(1, 500),
+                                      ReportAggregationOptions(1, 500));
+
+  options.check_transport = mock_check_transport_.GetFunc();
+  options.quota_transport = mock_quota_transport_.GetFunc();
+  options.report_transport = mock_report_transport_.GetFunc();
+
+  std::unique_ptr<ServiceControlClient> client =
+      CreateServiceControlClient("unknown", kServiceConfigId, options);
+
+  Status done_status = Status::UNKNOWN;
+  AllocateQuotaResponse quota_response;
+
+  client->Quota(quota_request1_, &quota_response,
+                [&done_status](Status status) { done_status = status; });
+
+  EXPECT_EQ(
+      done_status,
+      Status(
+          Code::INVALID_ARGUMENT,
+          "Invalid service name: library.googleapis.com Expecting: unknown"));
+
+  // count store callback
+  EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
+
+  Statistics stat;
+  Status stat_status = client->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 1);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 0);
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+// Error on default callback is not assigned
+TEST_F(ServiceControlClientImplQuotaTest,
+       TestQuotaWithNoDefaultQuotaTransport) {
+  ServiceControlClientOptions options(CheckAggregationOptions(1, 500, 1000),
+                                      QuotaAggregationOptions(1, 500),
+                                      ReportAggregationOptions(1, 500));
+
+  options.check_transport = mock_check_transport_.GetFunc();
+  options.quota_transport = nullptr;
+  options.report_transport = mock_report_transport_.GetFunc();
+
+  Status done_status = Status::UNKNOWN;
+  AllocateQuotaResponse quota_response;
+  std::unique_ptr<ServiceControlClient> client =
+      CreateServiceControlClient("unknown", kServiceConfigId, options);
+
+  client->Quota(quota_request1_, &quota_response,
+                [&done_status](Status status) { done_status = status; });
+
+  EXPECT_EQ(done_status, Status(Code::INVALID_ARGUMENT, "transport is NULL."));
+
+  // count store callback
+  EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
+
+  Statistics stat;
+  Status stat_status = client->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 1);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 0);
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+// Cached: false, Callback: stored
 TEST_F(ServiceControlClientImplQuotaTest,
        TestNonCachedQuotaWithStoredCallback) {
-  ServiceControlClientOptions options(CheckAggregationOptions(0, 500, 1000),
-                                      QuotaAggregationOptions(0, 500),
-                                      ReportAggregationOptions(0, 500));
-
-  options.check_transport = mock_check_transport_.GetFunc();
-  options.report_transport = mock_report_transport_.GetFunc();
-
-  int callbackCalledCount = 0;
-  options.quota_transport = [this, &callbackCalledCount](
-      const AllocateQuotaRequest& request, AllocateQuotaResponse* response,
-      TransportDoneFunc on_done) {
-    response = &pass_quota_response1_;
-
-    callbackCalledCount++;
-    on_done(Status::OK);
-  };
-
-  std::unique_ptr<ServiceControlClient> client_ =
-      CreateServiceControlClient(kServiceName, kServiceConfigId, options);
+  EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
+      .WillOnce(Invoke(&mock_quota_transport_,
+                       &MockQuotaTransport::AllocateQuotaWithStoredCallback));
 
   Status done_status = Status::UNKNOWN;
   AllocateQuotaResponse quota_response;
 
   client_->Quota(quota_request1_, &quota_response,
                  [&done_status](Status status) { done_status = status; });
-  ASSERT_TRUE(TextFormat::ParseFromString(kSuccessResponse1, &quota_response));
 
-  for (int i = 0; i < 10; i++) {
-    client_->Quota(quota_request1_, &quota_response,
-                   [&done_status](Status status) { done_status = status; });
-    ASSERT_TRUE(
-        TextFormat::ParseFromString(kSuccessResponse1, &quota_response));
-  }
+  EXPECT_EQ(done_status, Status::UNKNOWN);
+
+  // count store callback
+  EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 1);
+
+  // execute stored callback
+  mock_quota_transport_.on_done_vector_[0](done_status.OK);
   EXPECT_EQ(done_status, Status::OK);
-
-  EXPECT_EQ(callbackCalledCount, 11);
 
   Statistics stat;
   Status stat_status = client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
-  EXPECT_EQ(stat.total_called_quotas, 11);
+  EXPECT_EQ(stat.total_called_quotas, 1);
   EXPECT_EQ(stat.send_quotas_by_flush, 0);
-  EXPECT_EQ(stat.send_quotas_in_flight, 11);
+  EXPECT_EQ(stat.send_quotas_in_flight, 1);
 
   EXPECT_EQ(stat.send_report_operations, 0);
 }
 
-TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaWithStoredCallback) {
+// Cached: false, Callback: stored
+TEST_F(ServiceControlClientImplQuotaTest,
+       TestNonCachedQuotaWithStoredCallbackMultipleReqeusts) {
+  // Initialize client instance with cache disabled
   ServiceControlClientOptions options(CheckAggregationOptions(0, 500, 1000),
-                                      QuotaAggregationOptions(10, 500),
+                                      QuotaAggregationOptions(0, 500),
                                       ReportAggregationOptions(0, 500));
 
   options.check_transport = mock_check_transport_.GetFunc();
+  options.quota_transport = mock_quota_transport_.GetFunc();
   options.report_transport = mock_report_transport_.GetFunc();
 
-  int callbackCalledCount = 0;
-  options.quota_transport = [&callbackCalledCount](
-      const AllocateQuotaRequest& request, AllocateQuotaResponse* response,
-      TransportDoneFunc on_done) {
-    callbackCalledCount++;
-    on_done(Status::OK);
-  };
-
-  std::unique_ptr<ServiceControlClient> client_ =
+  std::unique_ptr<ServiceControlClient> client =
       CreateServiceControlClient(kServiceName, kServiceConfigId, options);
+
+  EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
+      .WillRepeatedly(
+          Invoke(&mock_quota_transport_,
+                 &MockQuotaTransport::AllocateQuotaWithStoredCallback));
+
+  Status done_status = Status::UNKNOWN;
+  AllocateQuotaResponse quota_response;
+
+  // call Quota 10 times
+  for (int i = 0; i < 10; i++) {
+    client->Quota(quota_request1_, &quota_response,
+                  [&done_status](Status status) { done_status = status; });
+    EXPECT_EQ(done_status, Status::UNKNOWN);
+  }
+
+  // count store callback
+  EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 10);
+
+  // execute stored callback
+  mock_quota_transport_.on_done_vector_[0](done_status.OK);
+  EXPECT_EQ(done_status, Status::OK);
+
+  Statistics stat;
+  Status stat_status = client->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 10);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 10);
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+// Cached: true, Callback: stored
+TEST_F(ServiceControlClientImplQuotaTest,
+       TestCachedQuotaWithStoredCallbackMultipleRequests) {
+  EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
+      .WillOnce(Invoke(&mock_quota_transport_,
+                       &MockQuotaTransport::AllocateQuotaWithStoredCallback));
 
   Status done_status = Status::UNKNOWN;
   AllocateQuotaResponse quota_response;
 
   client_->Quota(quota_request1_, &quota_response,
                  [&done_status](Status status) { done_status = status; });
+  EXPECT_EQ(done_status, Status::UNKNOWN);
 
+  // call Quota 10 times
   for (int i = 0; i < 10; i++) {
     client_->Quota(quota_request1_, &quota_response,
                    [&done_status](Status status) { done_status = status; });
+    EXPECT_EQ(done_status, Status::OK);
   }
 
-  EXPECT_EQ(done_status, Status::OK);
+  // count stored callback
+  EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 1);
 
-  EXPECT_EQ(callbackCalledCount, 1);
+  // execute stored callback
+  mock_quota_transport_.on_done_vector_[0](done_status.OK);
+  EXPECT_EQ(done_status, Status::OK);
 
   Statistics stat;
   Status stat_status = client_->GetStatistics(&stat);
@@ -192,7 +303,10 @@ TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaWithStoredCallback) {
   EXPECT_EQ(stat.send_report_operations, 0);
 }
 
-TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaWithCallback) {
+// Cached: false, Callback: in place
+TEST_F(ServiceControlClientImplQuotaTest,
+       TestNonCachedQuotaWithInStoredCallbackMultipleReqeusts) {
+  // Initialize client instance with cache disabled
   ServiceControlClientOptions options(CheckAggregationOptions(0, 500, 1000),
                                       QuotaAggregationOptions(0, 500),
                                       ReportAggregationOptions(0, 500));
@@ -201,89 +315,90 @@ TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaWithCallback) {
   options.quota_transport = mock_quota_transport_.GetFunc();
   options.report_transport = mock_report_transport_.GetFunc();
 
-  int callbackCalledCount = 0;
-
-  std::unique_ptr<ServiceControlClient> client_ =
+  std::unique_ptr<ServiceControlClient> client =
       CreateServiceControlClient(kServiceName, kServiceConfigId, options);
+
+  EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
+      .WillRepeatedly(
+          Invoke(&mock_quota_transport_,
+                 &MockQuotaTransport::AllocateQuotaWithInplaceCallback));
+
+  Status done_status = Status::UNKNOWN;
+  AllocateQuotaResponse quota_response;
+
+  // call Quota 10 times
+  for (int i = 0; i < 10; i++) {
+    client->Quota(quota_request1_, &quota_response,
+                  [&done_status](Status status) { done_status = status; });
+    EXPECT_EQ(done_status, Status::OK);
+  }
+
+  // count store callback
+  EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
+
+  Statistics stat;
+  Status stat_status = client->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 10);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 10);
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+// Cached: false, Callback: in place
+TEST_F(ServiceControlClientImplQuotaTest,
+       TestNonCachedQuotaWithInPlaceCallback) {
+  EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
+      .WillOnce(Invoke(&mock_quota_transport_,
+                       &MockQuotaTransport::AllocateQuotaWithInplaceCallback));
 
   Status done_status = Status::UNKNOWN;
   AllocateQuotaResponse quota_response;
 
   client_->Quota(quota_request1_, &quota_response,
-                 [&done_status](Status status) { done_status = status; },
-                 [&callbackCalledCount](const AllocateQuotaRequest& request,
-                                        AllocateQuotaResponse* response,
-                                        TransportDoneFunc on_done) {
-                   callbackCalledCount++;
-                   on_done(Status::OK);
-                 });
-
-  for (int i = 0; i < 10; i++) {
-    client_->Quota(quota_request1_, &quota_response,
-                   [&done_status](Status status) { done_status = status; },
-                   [&callbackCalledCount](const AllocateQuotaRequest& request,
-                                          AllocateQuotaResponse* response,
-                                          TransportDoneFunc on_done) {
-                     callbackCalledCount++;
-                     on_done(Status::OK);
-                   });
-  }
+                 [&done_status](Status status) { done_status = status; });
 
   EXPECT_EQ(done_status, Status::OK);
 
-  EXPECT_EQ(callbackCalledCount, 11);
+  // count store callback
+  EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
 
   Statistics stat;
   Status stat_status = client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
-  EXPECT_EQ(stat.total_called_quotas, 11);
+  EXPECT_EQ(stat.total_called_quotas, 1);
   EXPECT_EQ(stat.send_quotas_by_flush, 0);
-  EXPECT_EQ(stat.send_quotas_in_flight, 11);
+  EXPECT_EQ(stat.send_quotas_in_flight, 1);
 
   EXPECT_EQ(stat.send_report_operations, 0);
 }
 
-TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaWithCallback) {
-  ServiceControlClientOptions options(CheckAggregationOptions(0, 500, 1000),
-                                      QuotaAggregationOptions(10, 500),
-                                      ReportAggregationOptions(0, 500));
-
-  options.check_transport = mock_check_transport_.GetFunc();
-  options.quota_transport = mock_quota_transport_.GetFunc();
-  options.report_transport = mock_report_transport_.GetFunc();
-
-  int callbackCalledCount = 0;
-
-  std::unique_ptr<ServiceControlClient> client_ =
-      CreateServiceControlClient(kServiceName, kServiceConfigId, options);
+// Cache: false, Callback: in place
+TEST_F(ServiceControlClientImplQuotaTest,
+       TestCachedQuotaWithInPlaceCallbackMultipleRequests) {
+  EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
+      .WillOnce(Invoke(&mock_quota_transport_,
+                       &MockQuotaTransport::AllocateQuotaWithInplaceCallback));
 
   Status done_status = Status::UNKNOWN;
   AllocateQuotaResponse quota_response;
 
   client_->Quota(quota_request1_, &quota_response,
-                 [&done_status](Status status) { done_status = status; },
-                 [&callbackCalledCount](const AllocateQuotaRequest& request,
-                                        AllocateQuotaResponse* response,
-                                        TransportDoneFunc on_done) {
-                   callbackCalledCount++;
-                   on_done(Status::OK);
-                 });
-
-  for (int i = 0; i < 10; i++) {
-    client_->Quota(quota_request1_, &quota_response,
-                   [&done_status](Status status) { done_status = status; },
-                   [&callbackCalledCount](const AllocateQuotaRequest& request,
-                                          AllocateQuotaResponse* response,
-                                          TransportDoneFunc on_done) {
-                     callbackCalledCount++;
-                     on_done(Status::OK);
-                   });
-  }
+                 [&done_status](Status status) { done_status = status; });
 
   EXPECT_EQ(done_status, Status::OK);
 
-  EXPECT_EQ(callbackCalledCount, 1);
+  // call Quota 10 times
+  for (int i = 0; i < 10; i++) {
+    client_->Quota(quota_request1_, &quota_response,
+                   [&done_status](Status status) { done_status = status; });
+    EXPECT_EQ(done_status, Status::OK);
+  }
+
+  // count store callback
+  EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
 
   Statistics stat;
   Status stat_status = client_->GetStatistics(&stat);
@@ -296,72 +411,171 @@ TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaWithCallback) {
   EXPECT_EQ(stat.send_report_operations, 0);
 }
 
-TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaInSync) {
-  EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
-      .WillRepeatedly(Invoke(&mock_quota_transport_,
-                             &MockQuotaTransport::AllocateQuotaUsingThread));
-
-  ServiceControlClientOptions options(CheckAggregationOptions(0, 500, 1000),
-                                      QuotaAggregationOptions(0, 500),
-                                      ReportAggregationOptions(0, 500));
-
-  options.check_transport = mock_check_transport_.GetFunc();
-  options.quota_transport = mock_quota_transport_.GetFunc();
-  options.report_transport = mock_report_transport_.GetFunc();
-
-  std::unique_ptr<ServiceControlClient> client_ =
-      CreateServiceControlClient(kServiceName, kServiceConfigId, options);
-
+// Cache: false, Callback: local in place
+TEST_F(ServiceControlClientImplQuotaTest,
+       TestNonCachedQuotaWithLocalInPlaceCallback) {
+  Status done_status = Status::UNKNOWN;
   AllocateQuotaResponse quota_response;
-  Status done_status = client_->Quota(quota_request1_, &quota_response);
+
+  int callbackExecuteCount = 0;
+
+  client_->Quota(
+      quota_request1_, &quota_response,
+      [&done_status](Status status) { done_status = status; },
+      [this, &callbackExecuteCount](const AllocateQuotaRequest& request,
+                                    AllocateQuotaResponse* response,
+                                    TransportDoneFunc on_done) {
+        callbackExecuteCount++;
+        on_done(Status::OK);
+      });
+
   EXPECT_EQ(done_status, Status::OK);
 
-  for (int i = 0; i < 10; i++) {
-    done_status = client_->Quota(quota_request1_, &quota_response);
-    EXPECT_EQ(done_status, Status::OK);
-  }
+  EXPECT_EQ(callbackExecuteCount, 1);
+
+  // count store callback
+  EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
 
   Statistics stat;
   Status stat_status = client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
-  EXPECT_EQ(stat.total_called_quotas, 11);
+  EXPECT_EQ(stat.total_called_quotas, 1);
   EXPECT_EQ(stat.send_quotas_by_flush, 0);
-  EXPECT_EQ(stat.send_quotas_in_flight, 11);
+  EXPECT_EQ(stat.send_quotas_in_flight, 1);
 
   EXPECT_EQ(stat.send_report_operations, 0);
 }
 
-TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaInSync) {
+// Cache: false, Callback: in place
+TEST_F(ServiceControlClientImplQuotaTest,
+       TestNonCachedQuotaWithInPlaceCallbackInSync) {
+  EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
+      .WillOnce(Invoke(&mock_quota_transport_,
+                       &MockQuotaTransport::AllocateQuotaWithInplaceCallback));
+
+  AllocateQuotaResponse quota_response;
+
+  Status done_status = client_->Quota(quota_request1_, &quota_response);
+
+  EXPECT_EQ(done_status, Status::OK);
+
+  // count store callback
+  EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
+
+  Statistics stat;
+  Status stat_status = client_->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 1);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 1);
+
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+// Cache: true, Callback: in place
+TEST_F(ServiceControlClientImplQuotaTest,
+       TestCachedQuotaWithInPlaceCallbackInSyncMultipleRequests) {
+  EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
+      .WillOnce(Invoke(&mock_quota_transport_,
+                       &MockQuotaTransport::AllocateQuotaWithInplaceCallback));
+
+  AllocateQuotaResponse quota_response;
+
+  for (int i = 0; i < 10; i++) {
+    Status done_status = client_->Quota(quota_request1_, &quota_response);
+    EXPECT_EQ(done_status, Status::OK);
+  }
+
+  // count store callback
+  EXPECT_EQ(mock_quota_transport_.on_done_vector_.size(), 0);
+
+  Statistics stat;
+  Status stat_status = client_->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 10);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 1);
+
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+// Cache: false, Callback: thread
+TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaThread) {
   EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
       .WillRepeatedly(Invoke(&mock_quota_transport_,
                              &MockQuotaTransport::AllocateQuotaUsingThread));
 
-  ServiceControlClientOptions options(CheckAggregationOptions(0, 500, 1000),
-                                      QuotaAggregationOptions(10, 500),
-                                      ReportAggregationOptions(0, 500));
-
-  options.check_transport = mock_check_transport_.GetFunc();
-  options.quota_transport = mock_quota_transport_.GetFunc();
-  options.report_transport = mock_report_transport_.GetFunc();
-
-  std::unique_ptr<ServiceControlClient> client_ =
-      CreateServiceControlClient(kServiceName, kServiceConfigId, options);
-
+  Status done_status;
   AllocateQuotaResponse quota_response;
-  Status done_status = client_->Quota(quota_request1_, &quota_response);
-  EXPECT_EQ(done_status, Status::OK);
+
+  // Set the check status and response to be used in the on_check_done
+  mock_quota_transport_.done_status_ = done_status;
+  mock_quota_transport_.quota_response_ = &quota_response;
+
+  StatusPromise status_promise;
+  StatusFuture status_future = status_promise.get_future();
+
+  client_->Quota(quota_request1_, &quota_response,
+                 [&status_promise, &done_status](Status status) {
+                   StatusPromise moved_promise(std::move(status_promise));
+                   moved_promise.set_value(status);
+                 });
+
+  // Since it is not cached, transport should be called.
+  EXPECT_TRUE(MessageDifferencer::Equals(mock_quota_transport_.quota_request_,
+                                         quota_request1_));
+
+  status_future.wait();
+  EXPECT_EQ(status_future.get(), Status::OK);
+
+  Statistics stat;
+  Status stat_status = client_->GetStatistics(&stat);
+
+  EXPECT_EQ(stat_status, Status::OK);
+  EXPECT_EQ(stat.total_called_quotas, 1);
+  EXPECT_EQ(stat.send_quotas_by_flush, 0);
+  EXPECT_EQ(stat.send_quotas_in_flight, 1);
+
+  EXPECT_EQ(stat.send_report_operations, 0);
+}
+
+// Cache: true, Callback: thread
+TEST_F(ServiceControlClientImplQuotaTest,
+       TestCachedQuotaInSyncThreadMultipleRequests) {
+  EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
+      .WillRepeatedly(Invoke(&mock_quota_transport_,
+                             &MockQuotaTransport::AllocateQuotaUsingThread));
+
+  Status done_status;
+  AllocateQuotaResponse quota_response;
+
+  // Set the check status and response to be used in the on_check_done
+  mock_quota_transport_.done_status_ = done_status;
+  mock_quota_transport_.quota_response_ = &quota_response;
 
   for (int i = 0; i < 10; i++) {
-    done_status = client_->Quota(quota_request1_, &quota_response);
-    EXPECT_EQ(done_status, Status::OK);
+    StatusPromise status_promise;
+    StatusFuture status_future = status_promise.get_future();
+    client_->Quota(quota_request1_, &quota_response,
+                   [&status_promise, &done_status](Status status) {
+                     StatusPromise moved_promise(std::move(status_promise));
+                     moved_promise.set_value(status);
+                   });
+    // Since it is not cached, transport should be called.
+    EXPECT_TRUE(MessageDifferencer::Equals(mock_quota_transport_.quota_request_,
+                                           quota_request1_));
+    status_future.wait();
+    EXPECT_EQ(status_future.get(), Status::OK);
   }
 
   Statistics stat;
   Status stat_status = client_->GetStatistics(&stat);
 
   EXPECT_EQ(stat_status, Status::OK);
-  EXPECT_EQ(stat.total_called_quotas, 11);
+  EXPECT_EQ(stat.total_called_quotas, 10);
   EXPECT_EQ(stat.send_quotas_by_flush, 0);
   EXPECT_EQ(stat.send_quotas_in_flight, 1);
 

--- a/src/service_control_client_impl_test.cc
+++ b/src/service_control_client_impl_test.cc
@@ -1,4 +1,4 @@
-/* Copyright 2016 Google Inc. All Rights Reserved.
+/* Copyright 2017 Google Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@ limitations under the License.
 ==============================================================================*/
 
 #include "include/service_control_client.h"
+
+#include "src/service_control_client_impl_test.h"
 
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"
@@ -240,182 +242,6 @@ operations: {
   }
 }
 )";
-
-// A mocking class to mock CheckTransport interface.
-class MockCheckTransport {
- public:
-  MOCK_METHOD3(Check,
-               void(const CheckRequest&, CheckResponse*, TransportDoneFunc));
-  TransportCheckFunc GetFunc() {
-    return [this](const CheckRequest& request, CheckResponse* response,
-                  TransportDoneFunc on_done) {
-      this->Check(request, response, on_done);
-    };
-  }
-
-  MockCheckTransport() : check_response_(NULL) {
-    // To avoid vector resize which will cause segmentation fault.
-    on_done_vector_.reserve(100);
-  }
-
-  ~MockCheckTransport() {
-    for (auto& callback_thread : callback_threads_) {
-      callback_thread->join();
-    }
-  }
-
-  // The done callback is stored in on_done_. It MUST be called later.
-  void CheckWithStoredCallback(const CheckRequest& request,
-                               CheckResponse* response,
-                               TransportDoneFunc on_done) {
-    check_request_ = request;
-    if (check_response_) {
-      *response = *check_response_;
-    }
-    on_done_vector_.push_back(on_done);
-  }
-
-  // The done callback is called right away (in place).
-  void CheckWithInplaceCallback(const CheckRequest& request,
-                                CheckResponse* response,
-                                TransportDoneFunc on_done) {
-    check_request_ = request;
-    if (check_response_) {
-      *response = *check_response_;
-    }
-    on_done(done_status_);
-  }
-
-  // The done callback is called from a separate thread with check_status_
-  void CheckUsingThread(const CheckRequest& request, CheckResponse* response,
-                        TransportDoneFunc on_done) {
-    check_request_ = request;
-    Status done_status = done_status_;
-    CheckResponse* check_response = check_response_;
-    callback_threads_.push_back(std::unique_ptr<Thread>(
-        new Thread([on_done, done_status, check_response, response]() {
-          if (check_response) {
-            *response = *check_response;
-          }
-          on_done(done_status);
-        })));
-  }
-
-  // Saved check_request from mocked Transport::Check() call.
-  CheckRequest check_request_;
-  // If not NULL, the check response to send for mocked Transport::Check() call.
-  CheckResponse* check_response_;
-
-  // saved on_done callback from either Transport::Check() or
-  // Transport::Report().
-  std::vector<TransportDoneFunc> on_done_vector_;
-  // The status to send in on_done call back for Check() or Report().
-  Status done_status_;
-  // A vector to store thread objects used to call on_done callback.
-  std::vector<std::unique_ptr<std::thread>> callback_threads_;
-};
-
-// A mocking class to mock ReportTransport interface.
-class MockReportTransport {
- public:
-  MOCK_METHOD3(Report,
-               void(const ReportRequest&, ReportResponse*, TransportDoneFunc));
-  TransportReportFunc GetFunc() {
-    return [this](const ReportRequest& request, ReportResponse* response,
-                  TransportDoneFunc on_done) {
-      this->Report(request, response, on_done);
-    };
-  }
-
-  MockReportTransport() : report_response_(NULL) {
-    // To avoid vector resize which will cause segmentation fault.
-    on_done_vector_.reserve(100);
-  }
-
-  ~MockReportTransport() {
-    for (auto& callback_thread : callback_threads_) {
-      callback_thread->join();
-    }
-  }
-
-  // The done callback is stored in on_done_. It MUST be called later.
-  void ReportWithStoredCallback(const ReportRequest& request,
-                                ReportResponse* response,
-                                TransportDoneFunc on_done) {
-    report_request_ = request;
-    if (report_response_) {
-      *response = *report_response_;
-    }
-    on_done_vector_.push_back(on_done);
-  }
-
-  // The done callback is called right away (in place).
-  void ReportWithInplaceCallback(const ReportRequest& request,
-                                 ReportResponse* response,
-                                 TransportDoneFunc on_done) {
-    report_request_ = request;
-    if (report_response_) {
-      *response = *report_response_;
-    }
-    on_done(done_status_);
-  }
-
-  // The done callback is called from a separate thread with done_status_
-  void ReportUsingThread(const ReportRequest& request, ReportResponse* response,
-                         TransportDoneFunc on_done) {
-    report_request_ = request;
-    if (report_response_) {
-      *response = *report_response_;
-    }
-    Status done_status = done_status_;
-    callback_threads_.push_back(std::unique_ptr<Thread>(
-        new Thread([on_done, done_status]() { on_done(done_status); })));
-  }
-
-  // Saved report_request from mocked Transport::Report() call.
-  ReportRequest report_request_;
-  // If not NULL, the report response to send for mocked Transport::Report()
-  // call.
-  ReportResponse* report_response_;
-
-  // saved on_done callback from either Transport::Check() or
-  // Transport::Report().
-  std::vector<TransportDoneFunc> on_done_vector_;
-  // The status to send in on_done call back for Check() or Report().
-  Status done_status_;
-  // A vector to store thread objects used to call on_done callback.
-  std::vector<std::unique_ptr<Thread>> callback_threads_;
-};
-
-// A mocking class to mock Periodic_Timer interface.
-class MockPeriodicTimer {
- public:
-  MOCK_METHOD2(StartTimer,
-               std::unique_ptr<PeriodicTimer>(int, std::function<void()>));
-  PeriodicTimerCreateFunc GetFunc() {
-    return
-        [this](int interval_ms,
-               std::function<void()> func) -> std::unique_ptr<PeriodicTimer> {
-          return this->StartTimer(interval_ms, func);
-        };
-  }
-
-  class MockTimer : public PeriodicTimer {
-   public:
-    // Cancels the timer.
-    MOCK_METHOD0(Stop, void());
-  };
-
-  std::unique_ptr<PeriodicTimer> MyStartTimer(int interval_ms,
-                                              std::function<void()> callback) {
-    interval_ms_ = interval_ms;
-    callback_ = callback;
-    return std::unique_ptr<PeriodicTimer>(new MockTimer);
-  }
-
-  int interval_ms_;
-  std::function<void()> callback_;
-};
 
 }  // namespace
 

--- a/src/service_control_client_impl_test.cc
+++ b/src/service_control_client_impl_test.cc
@@ -15,7 +15,7 @@ limitations under the License.
 
 #include "include/service_control_client.h"
 
-#include "src/service_control_client_impl_test.h"
+#include "src/mock_transport.h"
 
 #include "gmock/gmock.h"
 #include "google/protobuf/text_format.h"

--- a/src/service_control_client_impl_test.h
+++ b/src/service_control_client_impl_test.h
@@ -1,0 +1,312 @@
+/* Copyright 2017 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef GOOGLE_SERVICE_CONTROL_CLIENT_SERVICE_CONTROL_CLIENT_IMPL_TEST_H_
+#define GOOGLE_SERVICE_CONTROL_CLIENT_SERVICE_CONTROL_CLIENT_IMPL_TEST_H_
+
+#include "include/service_control_client.h"
+
+#include "gmock/gmock.h"
+#include "google/protobuf/text_format.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "gtest/gtest.h"
+#include "utils/status_test_util.h"
+#include "utils/thread.h"
+
+#include <vector>
+
+using std::string;
+using ::google::api::servicecontrol::v1::Operation;
+using ::google::api::servicecontrol::v1::CheckRequest;
+using ::google::api::servicecontrol::v1::CheckResponse;
+using ::google::api::servicecontrol::v1::AllocateQuotaRequest;
+using ::google::api::servicecontrol::v1::AllocateQuotaResponse;
+using ::google::api::servicecontrol::v1::ReportRequest;
+using ::google::api::servicecontrol::v1::ReportResponse;
+using ::google::protobuf::TextFormat;
+using ::google::protobuf::util::MessageDifferencer;
+using ::google::protobuf::util::Status;
+using ::google::protobuf::util::error::Code;
+using ::testing::Invoke;
+using ::testing::Mock;
+using ::testing::_;
+
+namespace google {
+namespace service_control_client {
+namespace {
+
+// A mocking class to mock CheckTransport interface.
+class MockCheckTransport {
+ public:
+  MOCK_METHOD3(Check,
+               void(const CheckRequest&, CheckResponse*, TransportDoneFunc));
+  TransportCheckFunc GetFunc() {
+    return [this](const CheckRequest& request, CheckResponse* response,
+                  TransportDoneFunc on_done) {
+      this->Check(request, response, on_done);
+    };
+  }
+
+  MockCheckTransport() : check_response_(NULL) {
+    // To avoid vector resize which will cause segmentation fault.
+    on_done_vector_.reserve(100);
+  }
+
+  ~MockCheckTransport() {
+    for (auto& callback_thread : callback_threads_) {
+      callback_thread->join();
+    }
+  }
+
+  // The done callback is stored in on_done_. It MUST be called later.
+  void CheckWithStoredCallback(const CheckRequest& request,
+                               CheckResponse* response,
+                               TransportDoneFunc on_done) {
+    check_request_ = request;
+    if (check_response_) {
+      *response = *check_response_;
+    }
+    on_done_vector_.push_back(on_done);
+  }
+
+  // The done callback is called right away (in place).
+  void CheckWithInplaceCallback(const CheckRequest& request,
+                                CheckResponse* response,
+                                TransportDoneFunc on_done) {
+    check_request_ = request;
+    if (check_response_) {
+      *response = *check_response_;
+    }
+    on_done(done_status_);
+  }
+
+  // The done callback is called from a separate thread with check_status_
+  void CheckUsingThread(const CheckRequest& request, CheckResponse* response,
+                        TransportDoneFunc on_done) {
+    check_request_ = request;
+    Status done_status = done_status_;
+    CheckResponse* check_response = check_response_;
+    callback_threads_.push_back(std::unique_ptr<Thread>(
+        new Thread([on_done, done_status, check_response, response]() {
+          if (check_response) {
+            *response = *check_response;
+          }
+          on_done(done_status);
+        })));
+  }
+
+  // Saved check_request from mocked Transport::Check() call.
+  CheckRequest check_request_;
+  // If not NULL, the check response to send for mocked Transport::Check() call.
+  CheckResponse* check_response_;
+
+  // saved on_done callback from either Transport::Check() or
+  // Transport::Report().
+  std::vector<TransportDoneFunc> on_done_vector_;
+  // The status to send in on_done call back for Check() or Report().
+  Status done_status_;
+  // A vector to store thread objects used to call on_done callback.
+  std::vector<std::unique_ptr<std::thread>> callback_threads_;
+};
+
+
+// A mocking class to mock QuotaTransport interface.
+class MockQuotaTransport {
+ public:
+  MOCK_METHOD3(Quota,
+               void(const AllocateQuotaRequest&, AllocateQuotaResponse*, TransportDoneFunc));
+
+  TransportQuotaFunc GetFunc() {
+    return [this](const AllocateQuotaRequest& request, AllocateQuotaResponse* response,
+                  TransportDoneFunc on_done) {
+      std::cout << __FILE__ << ":" << __LINE__ << " " << std::endl;
+
+      this->Quota(request, response, on_done);
+    };
+  }
+
+  MockQuotaTransport() : quota_response_(NULL) {
+    // To avoid vector resize which will cause segmentation fault.
+    on_done_vector_.reserve(100);
+  }
+
+  ~MockQuotaTransport() {
+    for (auto& callback_thread : callback_threads_) {
+      callback_thread->join();
+    }
+  }
+
+  // The done callback is stored in on_done_. It MUST be called later.
+  void AllocateQuotaWithStoredCallback(const AllocateQuotaRequest& request,
+                               AllocateQuotaResponse* response,
+                               TransportDoneFunc on_done) {
+    quota_request_ = request;
+    if (quota_response_) {
+      *response = *quota_response_;
+    }
+    on_done_vector_.push_back(on_done);
+  }
+
+  // The done callback is called right away (in place).
+  void AllocateQuotaWithInplaceCallback(const AllocateQuotaRequest& request,
+                                AllocateQuotaResponse* response,
+                                TransportDoneFunc on_done) {
+    quota_request_ = request;
+    if (quota_response_) {
+      *response = *quota_response_;
+    }
+    on_done(done_status_);
+  }
+
+  // The done callback is called from a separate thread with quota_status_
+  void AllocateQuotaUsingThread(const AllocateQuotaRequest& request, AllocateQuotaResponse* response,
+                        TransportDoneFunc on_done) {
+    quota_request_ = request;
+    Status done_status = done_status_;
+    AllocateQuotaResponse* quota_response = quota_response_;
+    callback_threads_.push_back(std::unique_ptr<Thread>(
+        new Thread([on_done, done_status, quota_response, response]() {
+          if (quota_response) {
+            *response = *quota_response;
+          }
+          on_done(done_status);
+        })));
+  }
+
+  // Saved quota_request from mocked Transport::Quota() call.
+  AllocateQuotaRequest quota_request_;
+  // If not NULL, the quota response to send for mocked Transport::Quota() call.
+  AllocateQuotaResponse* quota_response_;
+
+  // saved on_done callback from either Transport::Quota() or
+  // Transport::Report().
+  std::vector<TransportDoneFunc> on_done_vector_;
+  // The status to send in on_done call back for Quota() or Report().
+  Status done_status_;
+  // A vector to store thread objects used to call on_done callback.
+  std::vector<std::unique_ptr<std::thread>> callback_threads_;
+};
+
+
+
+// A mocking class to mock ReportTransport interface.
+class MockReportTransport {
+ public:
+  MOCK_METHOD3(Report,
+               void(const ReportRequest&, ReportResponse*, TransportDoneFunc));
+  TransportReportFunc GetFunc() {
+    return [this](const ReportRequest& request, ReportResponse* response,
+                  TransportDoneFunc on_done) {
+      this->Report(request, response, on_done);
+    };
+  }
+
+  MockReportTransport() : report_response_(NULL) {
+    // To avoid vector resize which will cause segmentation fault.
+    on_done_vector_.reserve(100);
+  }
+
+  ~MockReportTransport() {
+    for (auto& callback_thread : callback_threads_) {
+      callback_thread->join();
+    }
+  }
+
+  // The done callback is stored in on_done_. It MUST be called later.
+  void ReportWithStoredCallback(const ReportRequest& request,
+                                ReportResponse* response,
+                                TransportDoneFunc on_done) {
+    report_request_ = request;
+    if (report_response_) {
+      *response = *report_response_;
+    }
+    on_done_vector_.push_back(on_done);
+  }
+
+  // The done callback is called right away (in place).
+  void ReportWithInplaceCallback(const ReportRequest& request,
+                                 ReportResponse* response,
+                                 TransportDoneFunc on_done) {
+    report_request_ = request;
+    if (report_response_) {
+      *response = *report_response_;
+    }
+    on_done(done_status_);
+  }
+
+  // The done callback is called from a separate thread with done_status_
+  void ReportUsingThread(const ReportRequest& request, ReportResponse* response,
+                         TransportDoneFunc on_done) {
+    report_request_ = request;
+    if (report_response_) {
+      *response = *report_response_;
+    }
+    Status done_status = done_status_;
+    callback_threads_.push_back(std::unique_ptr<Thread>(
+        new Thread([on_done, done_status]() { on_done(done_status); })));
+  }
+
+  // Saved report_request from mocked Transport::Report() call.
+  ReportRequest report_request_;
+  // If not NULL, the report response to send for mocked Transport::Report()
+  // call.
+  ReportResponse* report_response_;
+
+  // saved on_done callback from either Transport::Check() or
+  // Transport::Report().
+  std::vector<TransportDoneFunc> on_done_vector_;
+  // The status to send in on_done call back for Check() or Report().
+  Status done_status_;
+  // A vector to store thread objects used to call on_done callback.
+  std::vector<std::unique_ptr<Thread>> callback_threads_;
+};
+
+// A mocking class to mock Periodic_Timer interface.
+class MockPeriodicTimer {
+ public:
+  MOCK_METHOD2(StartTimer,
+               std::unique_ptr<PeriodicTimer>(int, std::function<void()>));
+  PeriodicTimerCreateFunc GetFunc() {
+    return
+        [this](int interval_ms,
+               std::function<void()> func) -> std::unique_ptr<PeriodicTimer> {
+          return this->StartTimer(interval_ms, func);
+        };
+  }
+
+  class MockTimer : public PeriodicTimer {
+   public:
+    // Cancels the timer.
+    MOCK_METHOD0(Stop, void());
+  };
+
+  std::unique_ptr<PeriodicTimer> MyStartTimer(int interval_ms,
+                                              std::function<void()> callback) {
+    interval_ms_ = interval_ms;
+    callback_ = callback;
+    return std::unique_ptr<PeriodicTimer>(new MockTimer);
+  }
+
+  int interval_ms_;
+  std::function<void()> callback_;
+};
+
+
+}  // namespace
+
+}  // namespace service_control_client
+}  // namespace google
+
+#endif  // GOOGLE_SERVICE_CONTROL_CLIENT_SERVICE_CONTROL_CLIENT_IMPL_TEST_H_


### PR DESCRIPTION
@qiwzhang 

Hello Wayne, could you please take a look?

1. Added missing methods in the base class of ServiceControlClient interface
2. Added src/service_control_client_impl_quota_test.cc testing Quota methods added to ServiceControlClientImpl.
3. Separated MockTransport methods into src/service_control_client_impl_test.h to share the class definitions

Separation of Check and Report test is not included this PR. I will create a separate PR for that.