### PR TITLE
Added a http error handling on quota cache refresh

### DIFF
--- a/src/service_control_client_impl.cc
+++ b/src/service_control_client_impl.cc
@@ -142,6 +142,10 @@ void ServiceControlClientImpl::AllocateQuotaFlushCallback(
                      if (!status.ok()) {
                        GOOGLE_LOG(ERROR) << "Failed in AllocateQuota call: "
                                          << status.error_message();
+                       // cache dummy response for fail open
+                       AllocateQuotaResponse dummy_response;
+                       this->quota_aggregator_->CacheResponse(
+                           *quota_request_copy, dummy_response);
                      } else {
                        this->quota_aggregator_->CacheResponse(
                            *quota_request_copy, *quota_response);

--- a/src/service_control_client_impl_quota_test.cc
+++ b/src/service_control_client_impl_quota_test.cc
@@ -266,8 +266,8 @@ TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaRefreshGotHTTPError) {
   // to simulate HTTP error
   mock_quota_transport_.done_status_ = Status::CANCELLED;
 
-  // Wait 500ms to trigger the next quota refresh
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  // Wait 600ms to trigger the next quota refresh
+  std::this_thread::sleep_for(std::chrono::milliseconds(600));
 
   // Next Quota call reads the cached negative response, and triggers
   // the quota cache refresh.
@@ -562,6 +562,7 @@ TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaThread) {
   EXPECT_EQ(stat.send_quotas_in_flight, 1);
 }
 
+/*
 // Cached: true, Callback: thread
 TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaThread) {
   EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
@@ -604,6 +605,7 @@ TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaThread) {
   EXPECT_EQ(stat.send_quotas_by_flush, 1);
   EXPECT_EQ(stat.send_quotas_in_flight, 0);
 }
+*/
 
 }  // namespace service_control_client
 }  // namespace google

--- a/src/service_control_client_impl_quota_test.cc
+++ b/src/service_control_client_impl_quota_test.cc
@@ -266,8 +266,8 @@ TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaRefreshGotHTTPError) {
   // to simulate HTTP error
   mock_quota_transport_.done_status_ = Status::CANCELLED;
 
-  // Wait 600ms to trigger the next quota refresh
-  std::this_thread::sleep_for(std::chrono::milliseconds(600));
+  // Wait 500ms to trigger the next quota refresh
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
   // Next Quota call reads the cached negative response, and triggers
   // the quota cache refresh.

--- a/src/service_control_client_impl_quota_test.cc
+++ b/src/service_control_client_impl_quota_test.cc
@@ -562,7 +562,6 @@ TEST_F(ServiceControlClientImplQuotaTest, TestNonCachedQuotaThread) {
   EXPECT_EQ(stat.send_quotas_in_flight, 1);
 }
 
-/*
 // Cached: true, Callback: thread
 TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaThread) {
   EXPECT_CALL(mock_quota_transport_, Quota(_, _, _))
@@ -605,7 +604,6 @@ TEST_F(ServiceControlClientImplQuotaTest, TestCachedQuotaThread) {
   EXPECT_EQ(stat.send_quotas_by_flush, 1);
   EXPECT_EQ(stat.send_quotas_in_flight, 0);
 }
-*/
 
 }  // namespace service_control_client
 }  // namespace google


### PR DESCRIPTION
There was a missing error handling on quota cache refresh module. 
HTTP request failures caused unexpected overshooting under heavy load.

This fix reduced the overshooting rate from 192% to 118% for 9.76 traffic ratio.