### PR TITLE
Remove INFO log when exiting

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,3 +18,17 @@ build:tsan --linkopt -ltsan
 
 # Release builds
 build:release -c opt
+
+# Add compile option for all C++ files
+build --cxxopt -Wnon-virtual-dtor
+build --cxxopt -Wformat
+build --cxxopt -Wformat-security
+
+fetch --incompatible_remove_native_git_repository=false
+fetch --incompatible_remove_native_http_archive=false
+fetch --incompatible_package_name_is_a_function=false
+
+build --incompatible_remove_native_git_repository=false
+build --incompatible_remove_native_http_archive=false
+build --incompatible_package_name_is_a_function=false
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,7 +17,7 @@
 new_git_repository(
     name = "googletest_git",
     build_file = "third_party/BUILD.googletest",
-    commit = "13206d6f53aaff844f2d3595a01ac83a29e383db",
+    commit = "d225acc90bc3a8c420a9bcd1f033033c1ccd7fe0",
     remote = "https://github.com/google/googletest.git",
 )
 
@@ -33,7 +33,7 @@ bind(
 
 git_repository(
     name = "boringssl",
-    commit = "2f29d38cc5e6c1bfae4ce22b4b032fb899cdb705",  # 2016-07-12
+    commit = "5b8bd1ba221804c81c8a92c6d1d353ef43a851ab",  # 2018-12-14
     remote = "https://boringssl.googlesource.com/boringssl",
 )
 
@@ -44,8 +44,8 @@ bind(
 
 git_repository(
     name = "protobuf_git",
-    commit = "320d56c833f835f40c56bdaf2a375768cdd1b334", # 3.0.0-beta-4
-    remote = "https://github.com/google/protobuf.git",
+    commit = "48cb18e5c419ddd23d9badcfe4e9df7bde1979b2",  # same as grpc
+    remote = "https://github.com/protocolbuffers/protobuf.git",
 )
 
 bind(
@@ -90,15 +90,3 @@ bind(
     actual = "@googleapis_git//:service_config",
 )
 
-# TODO(jaebong): Changed the protobuf repository from git to local copy
-# This move be rolled back when updated public protobuf is published
-new_local_repository(
-    name = "quotacontrol_git",
-    path = "proto",
-    build_file = "proto/BUILD",
-)
-
-bind(
-    name = "quotacontrol",
-    actual = "@quotacontrol_git//:quotacontrol",
-)

--- a/src/check_aggregator_impl.cc
+++ b/src/check_aggregator_impl.cc
@@ -241,7 +241,6 @@ Status CheckAggregatorImpl::FlushAll() {
   MutexLock lock(cache_mutex_);
   CheckCacheRemovedItemsHandler::StackBuffer::Swapper swapper(this,
                                                               &stack_buffer);
-  GOOGLE_LOG(INFO) << "Remove all entries of check aggregator.";
   if (cache_) {
     cache_->RemoveAll();
   }

--- a/src/quota_aggregator_impl.cc
+++ b/src/quota_aggregator_impl.cc
@@ -248,7 +248,6 @@ bool QuotaAggregatorImpl::ShouldDrop(const CacheElem& elem) const {
 
   in_flush_all_ = true;
 
-  GOOGLE_LOG(INFO) << "Remove all entries of check aggregator.";
   if (cache_) {
     cache_->RemoveAll();
   }

--- a/src/report_aggregator_impl.cc
+++ b/src/report_aggregator_impl.cc
@@ -172,7 +172,6 @@ Status ReportAggregatorImpl::FlushAll() {
   MutexLock lock(cache_mutex_);
   ReportCacheRemovedItemsHandler::StackBuffer::Swapper swapper(this,
                                                                &stack_buffer);
-  GOOGLE_LOG(INFO) << "Remove all entries of report aggregator.";
   if (cache_) {
     cache_->RemoveAll();
   }


### PR DESCRIPTION

Also updated some repositories, such as googletest, borning_ssl, and protobuf link

Move bazel.rc from tool/ folder to .bazelrc.  This is required by latest bazel.
