### PR TITLE
Add target for missing test

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -179,6 +179,16 @@ cc_test(
 )
 
 cc_test(
+    name = "check_aggregator_impl_test",
+    size = "small",
+    srcs = ["src/check_aggregator_impl_test.cc"],
+    deps = [
+        ":service_control_client_lib",
+        "@googletest_git//:googletest_main",
+    ],
+)
+
+cc_test(
     name = "simple_lru_cache_test",
     size = "small",
     srcs = ["utils/simple_lru_cache_test.cc"],


### PR DESCRIPTION
### Description

We have a unit test file (`src/check_aggregator_impl_test.cc`) that is currently not referenced from any `BUILD` targets.

I added a target to reference this missing test file. All tests in the missing file pass, and _I believe_ this increases test coverage.

### Testing Done

Commands run:
```
blaze build //:all
blaze test //:all
```

Output:
```
INFO: Elapsed time: 0.101s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action

//:check_aggregator_impl_test                                   (cached) PASSED in 0.7s
//:distribution_helper_test                                     (cached) PASSED in 0.2s
//:md5_test                                                     (cached) PASSED in 0.2s
//:money_utils_test                                             (cached) PASSED in 0.2s
//:operation_aggregator_test                                    (cached) PASSED in 0.2s
//:quota_aggregator_impl_test                                   (cached) PASSED in 2.5s
//:quota_operation_aggregator_test                              (cached) PASSED in 0.2s
//:report_aggregator_impl_test                                  (cached) PASSED in 1.4s
//:service_control_client_impl_quota_test                       (cached) PASSED in 0.8s
//:service_control_client_impl_test                             (cached) PASSED in 0.8s
//:signature_test                                               (cached) PASSED in 0.2s
//:simple_lru_cache_test                                        (cached) PASSED in 1.0s

Executed 0 out of 12 tests: 12 tests pass.
INFO: Build completed successfully, 1 total action
INFO: Build Event Protocol files produced successfully.
INFO: Build completed successfully, 1 total action
```