### PR TITLE
Fix `unused-result` warnings in build

### DIFF
--- a/src/check_aggregator_impl.cc
+++ b/src/check_aggregator_impl.cc
@@ -77,7 +77,7 @@ CheckAggregatorImpl::~CheckAggregatorImpl() {
   // FlushAll() will remove all cache items. For each removed item, it will call
   // flush_callback.  At destructor, it is better not to call the callback.
   SetFlushCallback(NULL);
-  FlushAll();
+  (void)FlushAll();
 }
 
 // Set the flush callback function.

--- a/src/operation_aggregator.cc
+++ b/src/operation_aggregator.cc
@@ -92,7 +92,7 @@ void MergeDeltaMetricValue(const MetricValue& from, MetricValue* to) {
       to->set_double_value(to->double_value() + from.double_value());
       break;
     case MetricValue::kDistributionValue:
-      DistributionHelper::Merge(from.distribution_value(),
+      (void)DistributionHelper::Merge(from.distribution_value(),
                                 to->mutable_distribution_value());
       break;
     default:

--- a/src/quota_aggregator_impl.cc
+++ b/src/quota_aggregator_impl.cc
@@ -88,7 +88,7 @@ QuotaAggregatorImpl::QuotaAggregatorImpl(const std::string& service_name,
 
 QuotaAggregatorImpl::~QuotaAggregatorImpl() {
   SetFlushCallback(NULL);
-  FlushAll();
+  (void)FlushAll();
 }
 
 // Sets the flush callback function.

--- a/src/quota_aggregator_impl_test.cc
+++ b/src/quota_aggregator_impl_test.cc
@@ -214,7 +214,7 @@ class QuotaAggregatorImplTest : public ::testing::Test {
   void FlushCallbackCallingBackToAggregator(
       const AllocateQuotaRequest& request) {
     flushed_.push_back(request);
-    aggregator_->CacheResponse(request, pass_response1_);
+    (void)aggregator_->CacheResponse(request, pass_response1_);
   }
 
   AllocateQuotaRequest request1_;

--- a/src/report_aggregator_impl.cc
+++ b/src/report_aggregator_impl.cc
@@ -69,7 +69,7 @@ ReportAggregatorImpl::~ReportAggregatorImpl() {
   // For each removed item, it will call flush_callback().
   // At the destructor, it is better not to call the callback.
   SetFlushCallback(NULL);
-  FlushAll();
+  (void)FlushAll();
 }
 
 // Set the flush callback function.

--- a/src/report_aggregator_impl_test.cc
+++ b/src/report_aggregator_impl_test.cc
@@ -194,7 +194,7 @@ class ReportAggregatorImplTest : public ::testing::Test {
 
   void FlushCallbackCallingBackToAggregator(const ReportRequest& request) {
     flushed_.push_back(request);
-    aggregator_->Flush();
+    (void)aggregator_->Flush();
   }
 
   ReportRequest request1_;

--- a/src/service_control_client_impl.cc
+++ b/src/service_control_client_impl.cc
@@ -114,7 +114,7 @@ ServiceControlClientImpl::ServiceControlClientImpl(
 
 ServiceControlClientImpl::~ServiceControlClientImpl() {
   // Flush out all cached data
-  FlushAll();
+  (void)FlushAll();
   if (flush_timer_) {
     flush_timer_->Stop();
   }
@@ -144,10 +144,10 @@ void ServiceControlClientImpl::AllocateQuotaFlushCallback(
                                          << status.error_message();
                        // cache dummy response for fail open
                        AllocateQuotaResponse dummy_response;
-                       this->quota_aggregator_->CacheResponse(
+                       (void)this->quota_aggregator_->CacheResponse(
                            *quota_request_copy, dummy_response);
                      } else {
-                       this->quota_aggregator_->CacheResponse(
+                       (void)this->quota_aggregator_->CacheResponse(
                            *quota_request_copy, *quota_response);
                      }
 
@@ -207,7 +207,7 @@ void ServiceControlClientImpl::Check(const CheckRequest& check_request,
                     [check_aggregator_copy, check_request_copy, check_response,
                      on_check_done](Status status) {
                       if (status.ok()) {
-                        check_aggregator_copy->CacheResponse(
+                        (void)check_aggregator_copy->CacheResponse(
                             *check_request_copy, *check_response);
                       } else {
                         GOOGLE_LOG(ERROR) << "Failed in Check call: "
@@ -271,13 +271,13 @@ void ServiceControlClientImpl::Quota(const AllocateQuotaRequest& quota_request,
                      quota_response, on_quota_done](Status status) {
 
                       if (status.ok()) {
-                        quota_aggregator_copy->CacheResponse(
+                        (void)quota_aggregator_copy->CacheResponse(
                             *quota_request_copy, *quota_response);
                       } else {
                         // on network error, failed open, reset in_flight flag
                         // to false
                         AllocateQuotaResponse dummy_response;
-                        quota_aggregator_copy->CacheResponse(
+                        (void)quota_aggregator_copy->CacheResponse(
                             *quota_request_copy, dummy_response);
 
                         GOOGLE_LOG(ERROR) << "Failed in Quota call: "

--- a/utils/distribution_helper_test.cc
+++ b/utils/distribution_helper_test.cc
@@ -409,13 +409,13 @@ bucket_counts: 2
 class DistributionHelperTest : public ::testing::Test {
  protected:
   DistributionHelperTest() {
-    helper_.InitExponential(2 /* num_finite_buckets */, 2 /* growth_factor */,
+    (void)helper_.InitExponential(2 /* num_finite_buckets */, 2 /* growth_factor */,
                             0.001 /* scale */, &exponential_distribution_);
     other_exponential_distribution_ = exponential_distribution_;
 
-    helper_.InitLinear(2 /* num_finite_buckets */, 2 /* width */,
+    (void)helper_.InitLinear(2 /* num_finite_buckets */, 2 /* width */,
                        1 /* offset */, &linear_distribution_);
-    helper_.InitExplicit({1.0, 3.0, 5.0}, &explicit_distribution_);
+    (void)helper_.InitExplicit({1.0, 3.0, 5.0}, &explicit_distribution_);
   }
 
   DistributionHelper helper_;
@@ -454,7 +454,7 @@ TEST_F(DistributionHelperTest, AddSample_OneValue_Exponential) {
   Distribution expected;
   ASSERT_TRUE(
       TextFormat::ParseFromString(kOneValueExponentialDistribution, &expected));
-  helper_.AddSample(kOneValueExponential, &exponential_distribution_);
+  (void)helper_.AddSample(kOneValueExponential, &exponential_distribution_);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(exponential_distribution_,
                                                       expected));
 }
@@ -463,7 +463,7 @@ TEST_F(DistributionHelperTest, AddSample_OneValue_Linear) {
   Distribution expected;
   ASSERT_TRUE(
       TextFormat::ParseFromString(kOneValueLinearDistribution, &expected));
-  helper_.AddSample(kOneValueLinear, &linear_distribution_);
+  (void)helper_.AddSample(kOneValueLinear, &linear_distribution_);
   EXPECT_TRUE(
       MessageDifferencer::ApproximatelyEquals(linear_distribution_, expected));
 }
@@ -472,7 +472,7 @@ TEST_F(DistributionHelperTest, AddSample_OneValue_Explicit) {
   Distribution expected;
   ASSERT_TRUE(
       TextFormat::ParseFromString(kOneValueExplicitDistribution, &expected));
-  helper_.AddSample(kOneValueExplicit, &explicit_distribution_);
+  (void)helper_.AddSample(kOneValueExplicit, &explicit_distribution_);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(explicit_distribution_,
                                                       expected));
 }
@@ -482,7 +482,7 @@ TEST_F(DistributionHelperTest, AddSample_TwoValues_Exponential) {
   ASSERT_TRUE(TextFormat::ParseFromString(kTwoValuesExponentialDistribution,
                                           &expected));
   for (double value : kTwoValuesExponential) {
-    helper_.AddSample(value, &exponential_distribution_);
+    (void)helper_.AddSample(value, &exponential_distribution_);
   }
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(exponential_distribution_,
                                                       expected));
@@ -493,7 +493,7 @@ TEST_F(DistributionHelperTest, AddSample_TwoValues_Linear) {
   ASSERT_TRUE(
       TextFormat::ParseFromString(kTwoValuesLinearDistribution, &expected));
   for (double value : kTwoValuesLinear) {
-    helper_.AddSample(value, &linear_distribution_);
+    (void)helper_.AddSample(value, &linear_distribution_);
   }
   EXPECT_TRUE(
       MessageDifferencer::ApproximatelyEquals(linear_distribution_, expected));
@@ -504,7 +504,7 @@ TEST_F(DistributionHelperTest, AddSample_TwoValues_Explicit) {
   ASSERT_TRUE(
       TextFormat::ParseFromString(kTwoValuesExplicitDistribution, &expected));
   for (double value : kTwoValuesExplicit) {
-    helper_.AddSample(value, &explicit_distribution_);
+    (void)helper_.AddSample(value, &explicit_distribution_);
   }
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(explicit_distribution_,
                                                       expected));
@@ -515,7 +515,7 @@ TEST_F(DistributionHelperTest, AddSample_MultipleValues_Exponential) {
   ASSERT_TRUE(TextFormat::ParseFromString(
       kMultipleValuesExponentialDistribution, &expected));
   for (double value : kMultipleValuesExponential) {
-    helper_.AddSample(value, &exponential_distribution_);
+    (void)helper_.AddSample(value, &exponential_distribution_);
   }
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(exponential_distribution_,
                                                       expected));
@@ -526,7 +526,7 @@ TEST_F(DistributionHelperTest, AddSample_MultipleValues_Linear) {
   ASSERT_TRUE(TextFormat::ParseFromString(kMultipleValuesLinearDistribution,
                                           &expected));
   for (double value : kMultipleValuesLinear) {
-    helper_.AddSample(value, &linear_distribution_);
+    (void)helper_.AddSample(value, &linear_distribution_);
   }
   EXPECT_TRUE(
       MessageDifferencer::ApproximatelyEquals(linear_distribution_, expected));
@@ -537,7 +537,7 @@ TEST_F(DistributionHelperTest, AddSample_MultipleValues_Explicit) {
   ASSERT_TRUE(TextFormat::ParseFromString(kMultipleValuesExplicitDistribution,
                                           &expected));
   for (double value : kMultipleValuesExplicit) {
-    helper_.AddSample(value, &explicit_distribution_);
+    (void)helper_.AddSample(value, &explicit_distribution_);
   }
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(explicit_distribution_,
                                                       expected));
@@ -549,7 +549,7 @@ TEST_F(DistributionHelperTest, AddSample_SpecialValues_Exponential) {
   ASSERT_TRUE(TextFormat::ParseFromString(kSpecialValuesExponentialDistribution,
                                           &expected));
   for (double value : kSpecialValues) {
-    helper_.AddSample(value, &exponential_distribution_);
+    (void)helper_.AddSample(value, &exponential_distribution_);
   }
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(exponential_distribution_,
                                                       expected));
@@ -560,7 +560,7 @@ TEST_F(DistributionHelperTest, AddSample_SpecialValues_Linear) {
   ASSERT_TRUE(
       TextFormat::ParseFromString(kSpecialValuesLinearDistribution, &expected));
   for (double value : kSpecialValues) {
-    helper_.AddSample(value, &linear_distribution_);
+    (void)helper_.AddSample(value, &linear_distribution_);
   }
   EXPECT_TRUE(
       MessageDifferencer::ApproximatelyEquals(linear_distribution_, expected));
@@ -571,7 +571,7 @@ TEST_F(DistributionHelperTest, AddSample_SpecialValues_Explicit) {
   ASSERT_TRUE(TextFormat::ParseFromString(kSpecialValuesExplicitDistribution,
                                           &expected));
   for (double value : kSpecialValues) {
-    helper_.AddSample(value, &explicit_distribution_);
+    (void)helper_.AddSample(value, &explicit_distribution_);
   }
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(explicit_distribution_,
                                                       expected));
@@ -584,14 +584,14 @@ TEST_F(DistributionHelperTest, Merge_TwoDistributions_SpecialValues) {
 
   int total_values = sizeof(kSpecialValues) / sizeof(double);
   for (int i = 0; i < total_values / 2; ++i) {
-    helper_.AddSample(kSpecialValues[i], &exponential_distribution_);
+    (void)helper_.AddSample(kSpecialValues[i], &exponential_distribution_);
   }
 
   for (int i = total_values / 2; i < total_values; ++i) {
-    helper_.AddSample(kSpecialValues[i], &other_exponential_distribution_);
+    (void)helper_.AddSample(kSpecialValues[i], &other_exponential_distribution_);
   }
 
-  helper_.Merge(other_exponential_distribution_, &exponential_distribution_);
+  (void)helper_.Merge(other_exponential_distribution_, &exponential_distribution_);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(exponential_distribution_,
                                                       expected));
 }
@@ -600,7 +600,7 @@ TEST_F(DistributionHelperTest, Merge_TwoDistributions_SpecialValues) {
 TEST_F(DistributionHelperTest, AddSample_UnknownDistribution) {
   Distribution distribution;
   Distribution expected;
-  helper_.AddSample(1, &distribution);
+  (void)helper_.AddSample(1, &distribution);
   EXPECT_TRUE(MessageDifferencer::Equals(distribution, expected));
 }
 
@@ -608,10 +608,10 @@ TEST_F(DistributionHelperTest, AddSample_UnknownDistribution) {
 // in tests.
 TEST_F(DistributionHelperTest, Merge_EmptyDistributions) {
   Distribution empty;
-  helper_.InitExponential(2, 2, 0.001, &empty);
+  (void)helper_.InitExponential(2, 2, 0.001, &empty);
   Distribution other_empty = empty;
 
-  helper_.Merge(other_empty, &empty);
+  (void)helper_.Merge(other_empty, &empty);
   EXPECT_EQ(0, empty.count());
 }
 
@@ -620,8 +620,8 @@ TEST_F(DistributionHelperTest, Merge_FromEmptyDistribution) {
   ASSERT_TRUE(
       TextFormat::ParseFromString(kOneValueExponentialDistribution, &expected));
 
-  helper_.AddSample(kOneValueExponential, &exponential_distribution_);
-  helper_.Merge(other_exponential_distribution_, &exponential_distribution_);
+  (void)helper_.AddSample(kOneValueExponential, &exponential_distribution_);
+  (void)helper_.Merge(other_exponential_distribution_, &exponential_distribution_);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(exponential_distribution_,
                                                       expected));
 }
@@ -631,8 +631,8 @@ TEST_F(DistributionHelperTest, Merge_ToEmptyDistribution) {
   ASSERT_TRUE(
       TextFormat::ParseFromString(kOneValueExponentialDistribution, &expected));
 
-  helper_.AddSample(kOneValueExponential, &exponential_distribution_);
-  helper_.Merge(other_exponential_distribution_, &exponential_distribution_);
+  (void)helper_.AddSample(kOneValueExponential, &exponential_distribution_);
+  (void)helper_.Merge(other_exponential_distribution_, &exponential_distribution_);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(exponential_distribution_,
                                                       expected));
 }
@@ -644,16 +644,16 @@ TEST_F(DistributionHelperTest, Merge_TwoDistributions) {
 
   int total_values = sizeof(kMultipleValuesExponential) / sizeof(double);
   for (int i = 0; i < total_values / 2; ++i) {
-    helper_.AddSample(kMultipleValuesExponential[i],
+    (void)helper_.AddSample(kMultipleValuesExponential[i],
                       &exponential_distribution_);
   }
 
   for (int i = total_values / 2; i < total_values; ++i) {
-    helper_.AddSample(kMultipleValuesExponential[i],
+    (void)helper_.AddSample(kMultipleValuesExponential[i],
                       &other_exponential_distribution_);
   }
 
-  helper_.Merge(other_exponential_distribution_, &exponential_distribution_);
+  (void)helper_.Merge(other_exponential_distribution_, &exponential_distribution_);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(exponential_distribution_,
                                                       expected));
 }
@@ -667,7 +667,7 @@ TEST_F(DistributionHelperTest, Merge_BucketMatch_Linear) {
   ASSERT_TRUE(TextFormat::ParseFromString(kLinearDistribution, &distribution));
   Distribution other_distribution = distribution;
 
-  helper_.Merge(other_distribution, &distribution);
+  (void)helper_.Merge(other_distribution, &distribution);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(distribution, expected));
 }
 
@@ -679,7 +679,7 @@ TEST_F(DistributionHelperTest,
   other_distribution.mutable_linear_buckets()->set_num_finite_buckets(10);
 
   Distribution expected = distribution;
-  helper_.Merge(other_distribution, &distribution);
+  (void)helper_.Merge(other_distribution, &distribution);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(distribution, expected));
 }
 
@@ -690,7 +690,7 @@ TEST_F(DistributionHelperTest, Merge_BucketNotMatch_Linear_DifferentWidth) {
   other_distribution.mutable_linear_buckets()->set_width(10);
 
   Distribution expected = distribution;
-  helper_.Merge(other_distribution, &distribution);
+  (void)helper_.Merge(other_distribution, &distribution);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(distribution, expected));
 }
 
@@ -701,7 +701,7 @@ TEST_F(DistributionHelperTest, Merge_BucketNotMatch_Linear_DifferentOffset) {
   other_distribution.mutable_linear_buckets()->set_offset(10);
 
   Distribution expected = distribution;
-  helper_.Merge(other_distribution, &distribution);
+  (void)helper_.Merge(other_distribution, &distribution);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(distribution, expected));
 }
 
@@ -715,7 +715,7 @@ TEST_F(DistributionHelperTest, Merge_BucketNotMatch_Explicit) {
       TextFormat::ParseFromString(kExplicitDistribution, &distribution));
   Distribution other_distribution = distribution;
 
-  helper_.Merge(other_distribution, &distribution);
+  (void)helper_.Merge(other_distribution, &distribution);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(distribution, expected));
 }
 
@@ -728,7 +728,7 @@ TEST_F(DistributionHelperTest,
   other_distribution.mutable_explicit_buckets()->clear_bounds();
 
   Distribution expected = distribution;
-  helper_.Merge(other_distribution, &distribution);
+  (void)helper_.Merge(other_distribution, &distribution);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(distribution, expected));
 }
 
@@ -740,7 +740,7 @@ TEST_F(DistributionHelperTest, Merge_BucketNotMatch_Explicit_DifferentBounds) {
   other_distribution.mutable_explicit_buckets()->set_bounds(0, 1.5);
 
   Distribution expected = distribution;
-  helper_.Merge(other_distribution, &distribution);
+  (void)helper_.Merge(other_distribution, &distribution);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(distribution, expected));
 }
 
@@ -754,7 +754,7 @@ TEST_F(DistributionHelperTest, Merge_BucketMatch_Exponential) {
       TextFormat::ParseFromString(kExponentialDistribution, &distribution));
   Distribution other_distribution = distribution;
 
-  helper_.Merge(other_distribution, &distribution);
+  (void)helper_.Merge(other_distribution, &distribution);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(distribution, expected));
 }
 
@@ -767,7 +767,7 @@ TEST_F(DistributionHelperTest,
   other_distribution.mutable_exponential_buckets()->set_num_finite_buckets(10);
 
   Distribution expected = distribution;
-  helper_.Merge(other_distribution, &distribution);
+  (void)helper_.Merge(other_distribution, &distribution);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(distribution, expected));
 }
 
@@ -780,7 +780,7 @@ TEST_F(DistributionHelperTest,
   other_distribution.mutable_exponential_buckets()->set_growth_factor(10);
 
   Distribution expected = distribution;
-  helper_.Merge(other_distribution, &distribution);
+  (void)helper_.Merge(other_distribution, &distribution);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(distribution, expected));
 }
 
@@ -793,7 +793,7 @@ TEST_F(DistributionHelperTest,
   other_distribution.mutable_exponential_buckets()->set_scale(10);
 
   Distribution expected = distribution;
-  helper_.Merge(other_distribution, &distribution);
+  (void)helper_.Merge(other_distribution, &distribution);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(distribution, expected));
 }
 
@@ -806,7 +806,7 @@ TEST_F(DistributionHelperTest, Merge_BucketNotMatch_Linear_Exponential) {
                                           &exponential));
 
   Distribution expected = exponential;
-  helper_.Merge(linear, &exponential);
+  (void)helper_.Merge(linear, &exponential);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(exponential, expected));
 }
 
@@ -819,7 +819,7 @@ TEST_F(DistributionHelperTest, Merge_BucketNotMatch_Explicit_Linear) {
                                           &explicit_distribution));
 
   Distribution expected = linear;
-  helper_.Merge(explicit_distribution, &linear);
+  (void)helper_.Merge(explicit_distribution, &linear);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(linear, expected));
 }
 
@@ -832,7 +832,7 @@ TEST_F(DistributionHelperTest, Merge_BucketNotMatch_Exponential_Explicit) {
                                           &explicit_distribution));
 
   Distribution expected = explicit_distribution;
-  helper_.Merge(exponential, &explicit_distribution);
+  (void)helper_.Merge(exponential, &explicit_distribution);
   EXPECT_TRUE(
       MessageDifferencer::ApproximatelyEquals(explicit_distribution, expected));
 }
@@ -853,7 +853,7 @@ TEST_F(DistributionHelperTest, Merge_BucketNotMatch_UnknownBucketOptions) {
 
   // The Merge function should not break in this situation.
   Distribution expected = distribution;
-  helper_.Merge(other_distribution, &distribution);
+  (void)helper_.Merge(other_distribution, &distribution);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(distribution, expected));
 }
 
@@ -864,7 +864,7 @@ TEST_F(DistributionHelperTest, Merge_DifferentBucketCountsSize) {
   Distribution to = exponential_distribution_;
 
   // The merge won't happen because the bucket size are different.
-  helper_.Merge(from, &to);
+  (void)helper_.Merge(from, &to);
   EXPECT_TRUE(
       MessageDifferencer::ApproximatelyEquals(to, exponential_distribution_));
 }
@@ -877,7 +877,7 @@ TEST_F(DistributionHelperTest, Merge_ZeroCount) {
   Distribution to = distribution;
   to.set_count(0);
 
-  helper_.Merge(distribution, &to);
+  (void)helper_.Merge(distribution, &to);
   EXPECT_TRUE(MessageDifferencer::ApproximatelyEquals(to, distribution));
 }
 


### PR DESCRIPTION
## Description

Fix `unused-result` warnings. These occur when the caller of a function does not check/store the return of the callee.

To "fix" these, I just casted the return to `void`. This is acceptable because we know the code works and the tests pass, so these warnings can be ignored...

## Testing Done

### No compilation changes

`blaze build //:all` still uses the cached compilation from `master`, meaning any code changed in this CL does not result in a change to the final binary. These c-style casts should not change the behavior of the code.

### All tests pass
```
blaze test //:all
```

```
INFO: Elapsed time: 0.089s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action

//:distribution_helper_test                                     (cached) PASSED in 0.2s
//:md5_test                                                     (cached) PASSED in 0.2s
//:money_utils_test                                             (cached) PASSED in 0.2s
//:operation_aggregator_test                                    (cached) PASSED in 0.2s
//:quota_aggregator_impl_test                                   (cached) PASSED in 2.5s
//:quota_operation_aggregator_test                              (cached) PASSED in 0.2s
//:report_aggregator_impl_test                                  (cached) PASSED in 1.4s
//:service_control_client_impl_quota_test                       (cached) PASSED in 0.8s
//:service_control_client_impl_test                             (cached) PASSED in 0.8s
//:signature_test                                               (cached) PASSED in 0.2s
//:simple_lru_cache_test                                        (cached) PASSED in 1.0s

Executed 0 out of 11 tests: 11 tests pass.
INFO: Build completed successfully, 1 total action
INFO: Build Event Protocol files produced successfully.
INFO: Build completed successfully, 1 total action
```

### Resolves all warnings

- See internal rabbit logs for passing build
- Can be easily verified once this CL is merged to `master`