### PR TITLE
Fix headers and more warnings

### DIFF
--- a/src/check_aggregator_impl_test.cc
+++ b/src/check_aggregator_impl_test.cc
@@ -148,7 +148,7 @@ class CheckAggregatorImplTest : public ::testing::Test {
 
   void FlushCallbackCallingBackToAggregator(const CheckRequest& request) {
     flushed_.push_back(request);
-    aggregator_->CacheResponse(request, pass_response1_);
+    (void)aggregator_->CacheResponse(request, pass_response1_);
   }
 
   CheckRequest request1_;

--- a/src/quota_operation_aggregator.cc
+++ b/src/quota_operation_aggregator.cc
@@ -17,8 +17,6 @@ limitations under the License.
 
 #include <iostream>
 
-#include <google/protobuf/text_format.h>
-
 #include "src/money_utils.h"
 #include "src/signature.h"
 #include "utils/distribution_helper.h"

--- a/src/quota_operation_aggregator.h
+++ b/src/quota_operation_aggregator.h
@@ -18,6 +18,7 @@ limitations under the License.
 
 #include "google/api/metric.pb.h"
 #include "google/api/servicecontrol/v1/quota_controller.pb.h"
+#include "google/protobuf/text_format.h"
 #include "utils/google_macros.h"
 
 namespace google {


### PR DESCRIPTION
### Description

- Fixed a `include` statement to correctly reference a non-standard library header.
- Fixed one last warning that was a result of PR #31 (did not see this warning before because this test was only enabled in #31)

### Testing Done

### All tests pass

```
bazel test //:all
```
```
INFO: Elapsed time: 5.636s, Critical Path: 5.05s
INFO: 28 processes: 28 linux-sandbox.
INFO: Build completed successfully, 30 total actions

//:distribution_helper_test                                     (cached) PASSED in 0.3s
//:simple_lru_cache_test                                        (cached) PASSED in 1.0s
//:check_aggregator_impl_test                                            PASSED in 0.7s
//:md5_test                                                              PASSED in 0.1s
//:money_utils_test                                                      PASSED in 0.1s
//:operation_aggregator_test                                             PASSED in 0.1s
//:quota_aggregator_impl_test                                            PASSED in 2.4s
//:quota_operation_aggregator_test                                       PASSED in 0.1s
//:report_aggregator_impl_test                                           PASSED in 1.3s
//:service_control_client_impl_quota_test                                PASSED in 0.7s
//:service_control_client_impl_test                                      PASSED in 0.8s
//:signature_test                                                        PASSED in 0.1s

Executed 10 out of 12 tests: 12 tests pass.
INFO: Build completed successfully, 30 total actions
INFO: Build Event Protocol files produced successfully.
INFO: Build completed successfully, 30 total actions
```

### Resolves all warnings

- Manual build was successful, as seen by internal sponge logs
- Can be easily verified once merged to `master`