### PR TITLE
Introduce factory and mocks

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -74,12 +74,12 @@ cc_library(
 
 cc_library(
     name = "mocks_lib",
+    testonly = 1,
     hdrs = ["test/mocks.h"],
     deps = [
-        "@googletest_git//:gtest",
         ":service_control_client_lib",
+        "@googletest_git//:gtest",
     ],
-    testonly = 1,
 )
 
 cc_test(

--- a/BUILD
+++ b/BUILD
@@ -29,6 +29,7 @@ cc_library(
         "src/quota_operation_aggregator.h",
         "src/report_aggregator_impl.cc",
         "src/report_aggregator_impl.h",
+        "src/service_control_client_factory_impl.h",
         "src/service_control_client_impl.cc",
         "src/service_control_client_impl.h",
         "src/signature.cc",
@@ -44,6 +45,7 @@ cc_library(
     hdrs = [
         "include/aggregation_options.h",
         "include/service_control_client.h",
+        "include/service_control_client_factory.h",
         "utils/distribution_helper.h",
         "utils/simple_lru_cache.h",
         "utils/simple_lru_cache_inl.h",
@@ -56,7 +58,7 @@ cc_library(
         "@boringssl//:crypto",
         "@googleapis_git//google/api:metric_cc_proto",
         "@googleapis_git//google/api/servicecontrol/v1:servicecontrol_cc_proto",
-         "@googleapis_git//google/type:money_cc_proto",
+        "@googleapis_git//google/type:money_cc_proto",
     ],
 )
 
@@ -68,6 +70,16 @@ cc_library(
         "utils/simple_lru_cache_inl.h",
     ],
     visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "mocks_lib",
+    hdrs = ["test/mocks.h"],
+    deps = [
+        "@googletest_git//:gtest",
+        ":service_control_client_lib",
+    ],
+    testonly = 1,
 )
 
 cc_test(
@@ -202,6 +214,16 @@ cc_test(
     ],
     deps = [
         ":simple_lru_cache",
+        "@googletest_git//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "mocks_test",
+    size = "small",
+    srcs = ["test/mocks_test.cc"],
+    deps = [
+        ":mocks_lib",
         "@googletest_git//:gtest_main",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -68,6 +68,7 @@ http_archive(
 )
 
 load("@googleapis_git//:repository_rules.bzl", "switched_rules_by_language")
+
 switched_rules_by_language(
     name = "com_google_googleapis_imports",
     cc = True,

--- a/include/service_control_client_factory.h
+++ b/include/service_control_client_factory.h
@@ -1,0 +1,48 @@
+/* Copyright 2021 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef GOOGLE_SERVICE_CONTROL_CLIENT_SERVICE_CONTROL_CLIENT_FACTORY_H_
+#define GOOGLE_SERVICE_CONTROL_CLIENT_SERVICE_CONTROL_CLIENT_FACTORY_H_
+
+#include "service_control_client.h"
+
+namespace google {
+namespace service_control_client {
+
+// A factory to create ServiceControlClients.
+// It does not provide any additional functionality other than making code
+// testable/mockable via dependency injection.
+class ServiceControlClientFactory {
+ public:
+  virtual ~ServiceControlClientFactory() {}
+
+  // Create a `ServiceControlClient` object.
+  virtual std::unique_ptr<ServiceControlClient> CreateClient(
+      const std::string& service_name, const std::string& service_config_id,
+    ServiceControlClientOptions& options) const = 0;
+
+  // ServiceControlClientFactory is neither copyable nor movable.
+  ServiceControlClientFactory(const ServiceControlClientFactory&) = delete;
+  ServiceControlClientFactory& operator=(const ServiceControlClientFactory&) =
+      delete;
+
+ protected:
+  ServiceControlClientFactory() {}
+};
+
+}  // namespace service_control_client
+}  // namespace google
+
+#endif  // GOOGLE_SERVICE_CONTROL_CLIENT_SERVICE_CONTROL_CLIENT_FACTORY_H_

--- a/src/service_control_client_factory_impl.h
+++ b/src/service_control_client_factory_impl.h
@@ -1,0 +1,40 @@
+/* Copyright 2021 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef GOOGLE_SERVICE_CONTROL_CLIENT_SERVICE_CONTROL_CLIENT_FACTORY_IMPL_H_
+#define GOOGLE_SERVICE_CONTROL_CLIENT_SERVICE_CONTROL_CLIENT_FACTORY_IMPL_H_
+
+#include "include/service_control_client_factory.h"
+#include "include/service_control_client.h"
+
+namespace google {
+namespace service_control_client {
+
+class ServiceControlClientFactoryImpl : public ServiceControlClientFactory {
+ public:
+   ServiceControlClientFactoryImpl() {}
+  ~ServiceControlClientFactoryImpl() override {}
+
+  std::unique_ptr<ServiceControlClient> CreateClient(
+      const std::string& service_name, const std::string& service_config_id,
+    ServiceControlClientOptions& options) const override {
+     return CreateServiceControlClient(service_name, service_config_id, options);
+   }
+};
+
+}  // namespace service_control_client
+}  // namespace google
+
+#endif  // GOOGLE_SERVICE_CONTROL_CLIENT_SERVICE_CONTROL_CLIENT_FACTORY_IMPL_H_

--- a/src/service_control_client_impl_test.cc
+++ b/src/service_control_client_impl_test.cc
@@ -15,6 +15,7 @@ limitations under the License.
 
 #include "include/service_control_client.h"
 
+#include "src/service_control_client_factory_impl.h"
 #include "src/mock_transport.h"
 
 #include "gmock/gmock.h"
@@ -275,8 +276,10 @@ class ServiceControlClientImplTest : public ::testing::Test {
         ReportAggregationOptions(1 /* entries */, 500 /*flush_interval_ms*/));
     options.check_transport = mock_check_transport_.GetFunc();
     options.report_transport = mock_report_transport_.GetFunc();
+
+    ServiceControlClientFactoryImpl factory;
     client_ =
-        CreateServiceControlClient(kServiceName, kServiceConfigId, options);
+        factory.CreateClient(kServiceName, kServiceConfigId, options);
   }
 
   // Tests non cached check request. Mocked transport::Check() is storing

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -1,0 +1,91 @@
+/* Copyright 2021 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef GOOGLE_SERVICE_CONTROL_CLIENT_MOCKS_H_
+#define GOOGLE_SERVICE_CONTROL_CLIENT_MOCKS_H_
+
+#include "gmock/gmock.h"
+#include "include/service_control_client_factory.h"
+#include "include/service_control_client.h"
+#include "google/protobuf/stubs/status.h"
+
+namespace google {
+namespace service_control_client {
+namespace testing {
+
+class MockServiceControlClient : public ServiceControlClient {
+ public:
+  MOCK_METHOD(void, Check, (
+      const ::google::api::servicecontrol::v1::CheckRequest& check_request,
+      ::google::api::servicecontrol::v1::CheckResponse* check_response,
+      DoneCallback on_check_done));
+
+  MOCK_METHOD(::google::protobuf::util::Status, Check, (
+      const ::google::api::servicecontrol::v1::CheckRequest& check_request,
+      ::google::api::servicecontrol::v1::CheckResponse* check_response));
+
+  MOCK_METHOD(void, Check, (
+      const ::google::api::servicecontrol::v1::CheckRequest& check_request,
+      ::google::api::servicecontrol::v1::CheckResponse* check_response,
+      DoneCallback on_check_done, TransportCheckFunc check_transport));
+
+  MOCK_METHOD(void, Quota, (
+      const ::google::api::servicecontrol::v1::AllocateQuotaRequest&
+          quota_request,
+      ::google::api::servicecontrol::v1::AllocateQuotaResponse* quota_response,
+      DoneCallback on_quota_done));
+
+  MOCK_METHOD(::google::protobuf::util::Status, Quota, (
+      const ::google::api::servicecontrol::v1::AllocateQuotaRequest&
+          quota_request,
+      ::google::api::servicecontrol::v1::AllocateQuotaResponse*
+          quota_response));
+
+  MOCK_METHOD(void, Quota, (
+      const ::google::api::servicecontrol::v1::AllocateQuotaRequest&
+          quota_request,
+      ::google::api::servicecontrol::v1::AllocateQuotaResponse* quota_response,
+      DoneCallback on_quota_done, TransportQuotaFunc quota_transport));
+
+  MOCK_METHOD(void, Report, (
+      const ::google::api::servicecontrol::v1::ReportRequest& report_request,
+      ::google::api::servicecontrol::v1::ReportResponse* report_response,
+      DoneCallback on_report_done));
+
+  MOCK_METHOD(::google::protobuf::util::Status, Report, (
+      const ::google::api::servicecontrol::v1::ReportRequest& report_request,
+      ::google::api::servicecontrol::v1::ReportResponse* report_response));
+
+  MOCK_METHOD(void, Report, (
+      const ::google::api::servicecontrol::v1::ReportRequest& report_request,
+      ::google::api::servicecontrol::v1::ReportResponse* report_response,
+      DoneCallback on_report_done, TransportReportFunc report_transport));
+
+  MOCK_METHOD(::google::protobuf::util::Status, GetStatistics,(
+      Statistics* stat), (const));
+};
+
+class MockServiceControlClientFactory : public ServiceControlClientFactory {
+ public:
+  MOCK_METHOD(std::unique_ptr<ServiceControlClient>, CreateClient,
+              (const std::string& service_name, const std::string& service_config_id,
+    ServiceControlClientOptions& options), (const));
+};
+
+}  // namespace testing
+}  // namespace service_control_client
+}  // namespace google
+
+#endif  // GOOGLE_SERVICE_CONTROL_CLIENT_MOCKS_H_

--- a/test/mocks_test.cc
+++ b/test/mocks_test.cc
@@ -1,0 +1,31 @@
+/* Copyright 2021 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "mocks.h"
+#include "gtest/gtest.h"
+
+namespace google {
+namespace service_control_client {
+namespace {
+
+// Simple unit tests to ensure mocks compile (all virtual methods are mocked).
+TEST(MocksTest, MocksCompile) {
+  testing::MockServiceControlClientFactory mock_factory;
+  testing::MockServiceControlClient mock_client;
+}
+
+}  // namespace
+}  // namespace service_control_client
+}  // namespace google


### PR DESCRIPTION
This will make it easier to unit test our filter code, especially for `AllocateQuota`.

```
//:check_aggregator_impl_test                                   (cached) PASSED in 0.6s
//:distribution_helper_test                                     (cached) PASSED in 0.2s
//:md5_test                                                     (cached) PASSED in 0.3s
//:mocks_test                                                   (cached) PASSED in 0.1s
//:money_utils_test                                             (cached) PASSED in 0.1s
//:operation_aggregator_test                                    (cached) PASSED in 0.3s
//:quota_aggregator_impl_test                                   (cached) PASSED in 2.3s
//:quota_operation_aggregator_test                              (cached) PASSED in 0.1s
//:report_aggregator_impl_test                                  (cached) PASSED in 1.3s
//:service_control_client_impl_quota_test                       (cached) PASSED in 0.7s
//:service_control_client_impl_test                             (cached) PASSED in 0.7s
//:signature_test                                               (cached) PASSED in 0.1s
//:simple_lru_cache_test                                        (cached) PASSED in 0.9s
```