### PR TITLE
b/188693470: go/asan error (signed_integer_overflow)

### DIFF
--- a/src/money_utils_test.cc
+++ b/src/money_utils_test.cc
@@ -88,7 +88,7 @@ TEST_F(MoneyUtilsTest, ValidateOutOfBound) {
   money.set_units(-1);
   money.set_nanos(-1000000000);
   EXPECT_ERROR_CODE(StatusCode::kInvalidArgument, ValidateMoney(money));
-  money.set_nanos(-INT32_MIN);
+  money.set_nanos(INT32_MIN);
   EXPECT_ERROR_CODE(StatusCode::kInvalidArgument, ValidateMoney(money));
 }
 


### PR DESCRIPTION
Fix -INT32_MIN in src/money_utils_test.cc