### PR TITLE
Add documentation for error response of quota cache

### DIFF
--- a/include/service_control_client.h
+++ b/include/service_control_client.h
@@ -35,7 +35,7 @@ namespace service_control_client {
 // Defines a function prototype used when an asynchronous transport call
 // is completed.
 using TransportDoneFunc =
-std::function<void(const ::google::protobuf::util::Status&)>;
+    std::function<void(const ::google::protobuf::util::Status&)>;
 
 // Defines a function prototype to make an asynchronous Check call to
 // the service control server.
@@ -242,7 +242,7 @@ struct Statistics {
 class ServiceControlClient {
  public:
   using DoneCallback =
-  std::function<void(const ::google::protobuf::util::Status&)>;
+      std::function<void(const ::google::protobuf::util::Status&)>;
 
   // Destructor
   virtual ~ServiceControlClient() {}
@@ -294,7 +294,7 @@ class ServiceControlClient {
   // quota_response must be alive until on_quota_done is called.
   virtual void Quota(
       const ::google::api::servicecontrol::v1::AllocateQuotaRequest&
-      quota_request,
+          quota_request,
       ::google::api::servicecontrol::v1::AllocateQuotaResponse* quota_response,
       DoneCallback on_quota_done) = 0;
 
@@ -303,7 +303,7 @@ class ServiceControlClient {
   // It allows caller to pass in a per_request transport function.
   virtual void Quota(
       const ::google::api::servicecontrol::v1::AllocateQuotaRequest&
-      quota_request,
+          quota_request,
       ::google::api::servicecontrol::v1::AllocateQuotaResponse* quota_response,
       DoneCallback on_quota_done, TransportQuotaFunc quota_transport) = 0;
 

--- a/include/service_control_client.h
+++ b/include/service_control_client.h
@@ -284,8 +284,8 @@ class ServiceControlClient {
   // When quota cache is enabled:
   //    No matter if there is a cache hit, `on_quota_done` is called with a
   //    cached ok status. In other words, the quota call is never blocked. This
-  //    may allow quota to exceed, but it can provide a consistent low latency
-  //    for all quota calls.
+  //    may allow quota to exceed, but it can provide all quota calls with a
+  //    consistently low latency.
   //    When cache hit occurs, `quota_response` is filled by the cached
   //    `AllocateQuotaResponse`. When cache miss occurs, a quota call is sent to
   //    the Controller service, and an empty `quota_response` is returned while

--- a/include/service_control_client.h
+++ b/include/service_control_client.h
@@ -35,7 +35,7 @@ namespace service_control_client {
 // Defines a function prototype used when an asynchronous transport call
 // is completed.
 using TransportDoneFunc =
-    std::function<void(const ::google::protobuf::util::Status&)>;
+std::function<void(const ::google::protobuf::util::Status&)>;
 
 // Defines a function prototype to make an asynchronous Check call to
 // the service control server.
@@ -242,7 +242,7 @@ struct Statistics {
 class ServiceControlClient {
  public:
   using DoneCallback =
-      std::function<void(const ::google::protobuf::util::Status&)>;
+  std::function<void(const ::google::protobuf::util::Status&)>;
 
   // Destructor
   virtual ~ServiceControlClient() {}
@@ -281,9 +281,20 @@ class ServiceControlClient {
       DoneCallback on_check_done, TransportCheckFunc check_transport) = 0;
 
   // An async quota call.
+  // on_quota_done is called with the quota request status after cached
+  // quota_response is returned in case of cache hit, otherwise called after
+  // quota_response is returned from the Controller service.
+  // When quota cache is enabled, quota_response can be mutated to contain a
+  // gRPC server error status in its allocate_errors field. This allows caching
+  // for fail-close errors. In other words, if quota cache is enabled, callers
+  // should check quota_response.allocate_errors for Controller service quota
+  // errors and gRPC errors (typically these errors are client-side errors
+  // corresponding to 4xx in HTTP).
+  //
+  // quota_response must be alive until on_quota_done is called.
   virtual void Quota(
       const ::google::api::servicecontrol::v1::AllocateQuotaRequest&
-          quota_request,
+      quota_request,
       ::google::api::servicecontrol::v1::AllocateQuotaResponse* quota_response,
       DoneCallback on_quota_done) = 0;
 
@@ -292,7 +303,7 @@ class ServiceControlClient {
   // It allows caller to pass in a per_request transport function.
   virtual void Quota(
       const ::google::api::servicecontrol::v1::AllocateQuotaRequest&
-          quota_request,
+      quota_request,
       ::google::api::servicecontrol::v1::AllocateQuotaResponse* quota_response,
       DoneCallback on_quota_done, TransportQuotaFunc quota_transport) = 0;
 

--- a/include/service_control_client.h
+++ b/include/service_control_client.h
@@ -292,9 +292,9 @@ class ServiceControlClient {
   //    the in-flight quota call is not completed.
   //    `quota_response` can be mutated to contain a gRPC server error status in
   //    its `allocate_errors` field. This allows caching for fail-close errors.
-  //    In other words, callers should check `quota_response.allocate_errors`
-  //    for Controller service quota errors and gRPC errors (typically these
-  //    errors are client-side errors corresponding to 4xx in HTTP).
+  //    This means callers should check `quota_response.allocate_errors` for
+  //    Controller service quota errors and gRPC errors (typically these errors
+  //    are client-side errors corresponding to 4xx in HTTP).
   // When quota cache is disabled:
   //    `on_quota_done` is called with the quota status returned from the
   //    Controller service. Unlike quota cache where a gRPC server error status

--- a/include/service_control_client.h
+++ b/include/service_control_client.h
@@ -282,12 +282,14 @@ class ServiceControlClient {
 
   // An async quota call.
   // When quota cache is enabled:
-  //    When cache hit occurs, `on_quota_done` is called with the cached
-  //    `quota_response`. When cache miss occurs, a quota call is sent to the
-  //    Controller service, and an empty `quota_response` is returned while the
-  //    in-flight quota call is not completed. In other words, the quota call is
-  //    never blocked. This may allow quota to exceed, but it can provide a
-  //    consistent low latency for all quota calls.
+  //    No matter if there is a cache hit, `on_quota_done` is called with a
+  //    cached ok status. In other words, the quota call is never blocked. This
+  //    may allow quota to exceed, but it can provide a consistent low latency
+  //    for all quota calls.
+  //    When cache hit occurs, `quota_response` is filled by the cached
+  //    `AllocateQuotaResponse`. When cache miss occurs, a quota call is sent to
+  //    the Controller service, and an empty `quota_response` is returned while
+  //    the in-flight quota call is not completed.
   //    `quota_response` can be mutated to contain a gRPC server error status in
   //    its `allocate_errors` field. This allows caching for fail-close errors.
   //    In other words, callers should check `quota_response.allocate_errors`


### PR DESCRIPTION
## Context
When AllocateQuota returns gRPC errors that are not in our fail-open status list, the current behaviour will mutate the AllocateQuotaResponse to include a QuotaError that contains the original gRPC error. https://github.com/cloudendpoints/service-control-client-cxx/blob/6529b9839fe790060ea1a1e4ddd4e61fe0720244/src/service_control_client_impl.cc#L171-L179

The callers of service_control_client would expect a raw gRPC error instead of a mutated response. We need to document this behaviour properly.

## Changes
Although the behaviour is implemented in [service_control_client_impl.cc](https://github.com/cloudendpoints/service-control-client-cxx/blob/master/src/service_control_client_impl.cc), we need to document this contract in [service_control_client.h](https://github.com/cloudendpoints/service-control-client-cxx/blob/master/include/service_control_client.h) since this is the interface.
